### PR TITLE
Enhancement/single schema many stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Add regex support for SQL
+
 ### Changed
 
 - Allow update dicts without operators in mongo update implementation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Allow update dicts without operators in mongo update implementation
+- Enable defining schemas once to be shared by different database technologies
+- Disable direct imports from `nqlstore.mongo`, `nqlstore.sql`, `nqlstore.redis`
 
 ## [0.0.1] - 2025-02-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Add regex support for SQL
+- Added regex support for SQL
 
 ### Changed
 
-- Allow update dicts without operators in mongo update implementation
-- Enable defining schemas once to be shared by different database technologies
-- Disable direct imports from `nqlstore.mongo`, `nqlstore.sql`, `nqlstore.redis`
+- Allowed update dicts without operators in mongo update implementation
+- Enabled defining schemas once to be shared by different database technologies
+- Disabled direct imports from `nqlstore.mongo`, `nqlstore.sql`, `nqlstore.redis`
 
 ## [0.0.1] - 2025-02-04
 

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,8 @@
+# Credits
+
+The following contributions have shaped this project.
+We don't want to forget them.
+
+## Initial Version of NQLstore
+
+- [Martin Ahindura](https://github.com/Tinitto)

--- a/README.md
+++ b/README.md
@@ -430,7 +430,6 @@ libraries = await store.delete(
 ## TODO
 
 - [ ] Implement dot notation for embedded documents and arrays (i.e. relationships in SQL)
-- [ ] Add regex search support for SQL (falling back to 'Like' queries in unsupported databases) and in redis
 - [ ] Merge all base Model and Field classes into one to allow definition of Models only once, 
   regardless of underlying database technology
 - [ ] Add sort by field not just by entire record (accept `dict`s instead of `int` in the sort argument)

--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ libraries = await redis_store.delete(
 ## TODO
 
 - [ ] Implement dot notation for embedded documents and arrays (i.e. relationships in SQL)
-- [ ] Add sort by field not just by entire record (accept `dict`s instead of `int` in the sort argument)
 - [ ] Add documentation site
 - [ ] Add example applications
 

--- a/README.md
+++ b/README.md
@@ -432,6 +432,8 @@ libraries = await store.delete(
 - [ ] Implement dot notation for embedded documents and arrays (i.e. relationships in SQL)
 - [ ] Add text search support for SQL and redis
 - [ ] Add regex search support for SQL (falling back to 'Like' queries in unsupported databases) and in redis
+- [ ] Merge all base Model and Field classes into one to allow definition of Models only once, 
+  regardless of underlying database technology
 - [ ] Add sort by field not just by entire record (accept `dict`s instead of `int` in the sort argument)
 - [ ] Add documentation site
 - [ ] Add example applications

--- a/README.md
+++ b/README.md
@@ -430,7 +430,6 @@ libraries = await store.delete(
 ## TODO
 
 - [ ] Implement dot notation for embedded documents and arrays (i.e. relationships in SQL)
-- [ ] Add text search support for SQL and redis
 - [ ] Add regex search support for SQL (falling back to 'Like' queries in unsupported databases) and in redis
 - [ ] Merge all base Model and Field classes into one to allow definition of Models only once, 
   regardless of underlying database technology

--- a/nqlstore/__init__.py
+++ b/nqlstore/__init__.py
@@ -1,0 +1,21 @@
+from ._field import Field, Relationship
+from ._mongo import MongoModel, MongoStore, PydanticObjectId
+from ._redis import EmbeddedJsonModel, HashModel, JsonModel, RedisStore
+from ._sql import SQLModel, SQLStore
+from .query.parsers import QueryParser
+
+__all__ = [
+    "SQLStore",
+    "SQLModel",
+    "MongoModel",
+    "MongoStore",
+    "PydanticObjectId",
+    "Field",
+    "Relationship",
+    "RedisStore",
+    "HashModel",
+    "JsonModel",
+    "EmbeddedJsonModel",
+    "QueryParser",
+    "query",
+]

--- a/nqlstore/_field.py
+++ b/nqlstore/_field.py
@@ -1,0 +1,271 @@
+"""The main module containing the default types to be imported"""
+
+from typing import (
+    AbstractSet,
+    Any,
+    Dict,
+    Mapping,
+    Optional,
+    Sequence,
+    Type,
+    Union,
+    overload,
+)
+
+from aredis_om.model.model import FieldInfo as _RedisFieldInfo
+from aredis_om.model.model import VectorFieldOptions
+from sqlmodel._compat import post_init_field_info
+from sqlmodel.main import Column
+from sqlmodel.main import FieldInfo as _SqlFieldInfo
+from sqlmodel.main import (
+    NoArgAnyCallable,
+    OnDeleteType,
+    Relationship,
+    Undefined,
+    UndefinedType,
+)
+
+
+class FieldInfo(_SqlFieldInfo, _RedisFieldInfo):
+    def __init__(self, default: Any = Undefined, **kwargs: Any) -> None:
+        super().__init__(default=default, **kwargs)
+
+
+# include sa_type, sa_column_args, sa_column_kwargs
+@overload
+def Field(
+    default: Any = Undefined,
+    *,
+    default_factory: Optional[NoArgAnyCallable] = None,
+    alias: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    exclude: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    include: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    const: Optional[bool] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    multiple_of: Optional[float] = None,
+    max_digits: Optional[int] = None,
+    decimal_places: Optional[int] = None,
+    min_items: Optional[int] = None,
+    max_items: Optional[int] = None,
+    unique_items: Optional[bool] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    allow_mutation: bool = True,
+    regex: Optional[str] = None,
+    discriminator: Optional[str] = None,
+    repr: bool = True,
+    primary_key: Union[bool, UndefinedType] = False,
+    foreign_key: Any = Undefined,
+    unique: Union[bool, UndefinedType] = Undefined,
+    nullable: Union[bool, UndefinedType] = Undefined,
+    index: Union[bool, UndefinedType] = Undefined,
+    sa_type: Union[Type[Any], UndefinedType] = Undefined,
+    sa_column_args: Union[Sequence[Any], UndefinedType] = Undefined,
+    sa_column_kwargs: Union[Mapping[str, Any], UndefinedType] = Undefined,
+    sortable: Union[bool, UndefinedType] = Undefined,
+    case_sensitive: Union[bool, UndefinedType] = Undefined,
+    full_text_search: Union[bool, UndefinedType] = Undefined,
+    vector_options: Optional[VectorFieldOptions] = None,
+    schema_extra: Optional[Dict[str, Any]] = None,
+) -> Any: ...
+
+
+# When foreign_key is str, include ondelete
+# include sa_type, sa_column_args, sa_column_kwargs
+@overload
+def Field(
+    default: Any = Undefined,
+    *,
+    default_factory: Optional[NoArgAnyCallable] = None,
+    alias: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    exclude: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    include: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    const: Optional[bool] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    multiple_of: Optional[float] = None,
+    max_digits: Optional[int] = None,
+    decimal_places: Optional[int] = None,
+    min_items: Optional[int] = None,
+    max_items: Optional[int] = None,
+    unique_items: Optional[bool] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    allow_mutation: bool = True,
+    regex: Optional[str] = None,
+    discriminator: Optional[str] = None,
+    repr: bool = True,
+    primary_key: Union[bool, UndefinedType] = False,
+    foreign_key: str,
+    ondelete: Union[OnDeleteType, UndefinedType] = Undefined,
+    unique: Union[bool, UndefinedType] = Undefined,
+    nullable: Union[bool, UndefinedType] = Undefined,
+    index: Union[bool, UndefinedType] = Undefined,
+    sa_type: Union[Type[Any], UndefinedType] = Undefined,
+    sa_column_args: Union[Sequence[Any], UndefinedType] = Undefined,
+    sa_column_kwargs: Union[Mapping[str, Any], UndefinedType] = Undefined,
+    sortable: Union[bool, UndefinedType] = Undefined,
+    case_sensitive: Union[bool, UndefinedType] = Undefined,
+    full_text_search: Union[bool, UndefinedType] = Undefined,
+    vector_options: Optional[VectorFieldOptions] = None,
+    schema_extra: Optional[Dict[str, Any]] = None,
+) -> Any: ...
+
+
+# Include sa_column, don't include
+# primary_key
+# foreign_key
+# ondelete
+# unique
+# nullable
+# index
+# sa_type
+# sa_column_args
+# sa_column_kwargs
+@overload
+def Field(
+    default: Any = Undefined,
+    *,
+    default_factory: Optional[NoArgAnyCallable] = None,
+    alias: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    exclude: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    include: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    const: Optional[bool] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    multiple_of: Optional[float] = None,
+    max_digits: Optional[int] = None,
+    decimal_places: Optional[int] = None,
+    min_items: Optional[int] = None,
+    max_items: Optional[int] = None,
+    unique_items: Optional[bool] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    allow_mutation: bool = True,
+    regex: Optional[str] = None,
+    discriminator: Optional[str] = None,
+    repr: bool = True,
+    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
+    sortable: Union[bool, UndefinedType] = Undefined,
+    case_sensitive: Union[bool, UndefinedType] = Undefined,
+    full_text_search: Union[bool, UndefinedType] = Undefined,
+    vector_options: Optional[VectorFieldOptions] = None,
+    schema_extra: Optional[Dict[str, Any]] = None,
+) -> Any: ...
+
+
+def Field(
+    default: Any = Undefined,
+    *,
+    default_factory: Optional[NoArgAnyCallable] = None,
+    alias: Optional[str] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    exclude: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    include: Union[
+        AbstractSet[Union[int, str]], Mapping[Union[int, str], Any], Any
+    ] = None,
+    const: Optional[bool] = None,
+    gt: Optional[float] = None,
+    ge: Optional[float] = None,
+    lt: Optional[float] = None,
+    le: Optional[float] = None,
+    multiple_of: Optional[float] = None,
+    max_digits: Optional[int] = None,
+    decimal_places: Optional[int] = None,
+    min_items: Optional[int] = None,
+    max_items: Optional[int] = None,
+    unique_items: Optional[bool] = None,
+    min_length: Optional[int] = None,
+    max_length: Optional[int] = None,
+    allow_mutation: bool = True,
+    regex: Optional[str] = None,
+    discriminator: Optional[str] = None,
+    repr: bool = True,
+    primary_key: Union[bool, UndefinedType] = False,
+    foreign_key: Any = Undefined,
+    ondelete: Union[OnDeleteType, UndefinedType] = Undefined,
+    unique: Union[bool, UndefinedType] = Undefined,
+    nullable: Union[bool, UndefinedType] = Undefined,
+    index: Union[bool, UndefinedType] = Undefined,
+    sa_type: Union[Type[Any], UndefinedType] = Undefined,
+    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
+    sa_column_args: Union[Sequence[Any], UndefinedType] = Undefined,
+    sa_column_kwargs: Union[Mapping[str, Any], UndefinedType] = Undefined,
+    sortable: Union[bool, UndefinedType] = Undefined,
+    case_sensitive: Union[bool, UndefinedType] = Undefined,
+    full_text_search: Union[bool, UndefinedType] = Undefined,
+    vector_options: Optional[VectorFieldOptions] = None,
+    schema_extra: Optional[Dict[str, Any]] = None,
+) -> Any:
+    current_schema_extra = schema_extra or {}
+    field_info = FieldInfo(
+        default,
+        default_factory=default_factory,
+        alias=alias,
+        title=title,
+        description=description,
+        exclude=exclude,
+        include=include,
+        const=const,
+        gt=gt,
+        ge=ge,
+        lt=lt,
+        le=le,
+        multiple_of=multiple_of,
+        max_digits=max_digits,
+        decimal_places=decimal_places,
+        min_items=min_items,
+        max_items=max_items,
+        unique_items=unique_items,
+        min_length=min_length,
+        max_length=max_length,
+        allow_mutation=allow_mutation,
+        regex=regex,
+        discriminator=discriminator,
+        repr=repr,
+        primary_key=primary_key,
+        foreign_key=foreign_key,
+        ondelete=ondelete,
+        unique=unique,
+        nullable=nullable,
+        index=index,
+        sa_type=sa_type,
+        sa_column=sa_column,
+        sa_column_args=sa_column_args,
+        sa_column_kwargs=sa_column_kwargs,
+        sortable=sortable,
+        case_sensitive=case_sensitive,
+        full_text_search=full_text_search,
+        vector_options=vector_options,
+        **current_schema_extra,
+    )
+    post_init_field_info(field_info)
+    return field_info

--- a/nqlstore/query/selectors.py
+++ b/nqlstore/query/selectors.py
@@ -32,6 +32,15 @@ _NeSelector = TypedDict("_NeSelector", {"$ne": Any})
 _NinSelector = TypedDict("_NinSelector", {"$nin": list[Any]})
 """field is not in list: ``{ $nin: [ <value1>, <value2> ... <valueN> ] }``"""
 
+
+_RegexSelector = TypedDict(
+    "_RegexSelector", {"$regex": str, "$options": str}, total=False
+)
+"""field matches given regular expression: ``{ "$regex": "pattern", "$options": "<options>" }``
+
+``$options`` is optional
+"""
+
 ## Element
 _ExistsSelector = TypedDict("_ExistsSelector", {"$exists": bool})
 """field exists: ``{ $exists: <boolean> }``"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ from nqlstore.redis import HashModel, RedisStore
 from nqlstore.sql import Field as SqlField
 from nqlstore.sql import SQLModel, SQLStore
 
-from .utils import insert_test_data
+from .utils import get_regex_test_params, insert_test_data
 
 
 class MongoLibrary(Document):
@@ -97,6 +97,12 @@ async def inserted_redis_libs(redis_store):
     yield inserted_libs
 
 
+@pytest.fixture
+def regex_params_redis(inserted_redis_libs):
+    """The regex test params for redis"""
+    yield get_regex_test_params(inserted_redis_libs)
+
+
 @pytest_asyncio.fixture()
 async def inserted_mongo_libs(mongo_store):
     """The libraries inserted in the mongodb store"""
@@ -106,6 +112,12 @@ async def inserted_mongo_libs(mongo_store):
     yield inserted_libs
 
 
+@pytest.fixture
+def regex_params_mongo(inserted_mongo_libs):
+    """The regex test params for mongo"""
+    yield get_regex_test_params(inserted_mongo_libs)
+
+
 @pytest_asyncio.fixture()
 async def inserted_sql_libs(sql_store):
     """The libraries inserted in the sql store"""
@@ -113,6 +125,12 @@ async def inserted_sql_libs(sql_store):
         sql_store, library_model=SqlLibrary, book_model=SqlBook
     )
     yield inserted_libs
+
+
+@pytest.fixture
+def regex_params_sql(inserted_sql_libs):
+    """The regex test params for sql"""
+    yield get_regex_test_params(inserted_sql_libs)
 
 
 @pytest_asyncio.fixture()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,62 +1,50 @@
+from typing import Generic, TypeVar
+
 import pymongo
 import pytest
 import pytest_asyncio
 import redis
+from pydantic import BaseModel
 
-from nqlstore.mongo import Document, Indexed, MongoStore, PydanticObjectId
+from nqlstore import (
+    Field,
+    HashModel,
+    MongoModel,
+    MongoStore,
+    PydanticObjectId,
+    RedisStore,
+    SQLModel,
+    SQLStore,
+)
 from nqlstore.query.parsers import QueryParser
-from nqlstore.redis import Field as RedisField
-from nqlstore.redis import HashModel, RedisStore
-from nqlstore.sql import Field as SqlField
-from nqlstore.sql import SQLModel, SQLStore
 
 from .utils import get_regex_test_params, insert_test_data
 
+_T = TypeVar("_T")
 
-class MongoLibrary(Document):
-    address: str
-    name: str
+
+class Library(BaseModel):
+    address: str = Field(index=True, full_text_search=True)
+    name: str = Field(index=True, full_text_search=True)
 
     class Settings:
         name = "libraries"
 
 
-class MongoBook(Document):
-    title: Indexed(str)
-    library_id: PydanticObjectId
+class Book(BaseModel, Generic[_T]):
+    title: str = Field(index=True)
+    library_id: _T | None = Field(default=None, foreign_key="sqllibrary.id")
 
     class Settings:
         name = "books"
 
 
-class RedisLibrary(HashModel):
-    address: str = RedisField(index=True, full_text_search=True)
-    name: str = RedisField(index=True, full_text_search=True)
-
-    @property
-    def id(self):
-        return self.pk
-
-
-class RedisBook(HashModel):
-    title: str = RedisField(index=True)
-    library_id: str
-
-    @property
-    def id(self):
-        return self.pk
-
-
-class SqlLibrary(SQLModel, table=True):
-    id: int | None = SqlField(default=None, primary_key=True)
-    address: str
-    name: str
-
-
-class SqlBook(SQLModel, table=True):
-    id: int | None = SqlField(default=None, primary_key=True)
-    title: str
-    library_id: int = SqlField(default=None, foreign_key="sqllibrary.id")
+MongoLibrary = MongoModel("MongoLibrary", Library)
+MongoBook = MongoModel("MongoBook", Book[PydanticObjectId])
+RedisLibrary = HashModel("RedisLibrary", Library)
+RedisBook = HashModel("RedisBook", Book[str])
+SqlLibrary = SQLModel("SqlLibrary", Library)
+SqlBook = SQLModel("SqlBook", Book[int])
 
 
 @pytest.fixture

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -3,16 +3,25 @@ import re
 import pytest
 
 from tests.conftest import MongoBook, MongoLibrary
-from tests.utils import insert_test_data, load_fixture
+from tests.utils import load_fixture
 
 _LIBRARY_DATA = load_fixture("libraries.json")
 
 
 @pytest.mark.asyncio
 async def test_find(mongo_store, inserted_mongo_libs):
-    """Update should update the items that match the filter"""
-    got = await mongo_store.find(MongoLibrary, MongoLibrary.id != None, skip=1)
+    """Find should find the items that match the filter"""
+    got = await mongo_store.find(MongoLibrary, {}, skip=1)
     expected = [v for idx, v in enumerate(inserted_mongo_libs) if idx >= 1]
+    assert got == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("index", range(4))
+async def test_regex_find(mongo_store, regex_params_mongo, index):
+    """Find with regex should find the items that match the regex"""
+    filters, expected = regex_params_mongo[index]
+    got = await mongo_store.find(MongoLibrary, filters)
     assert got == expected
 
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tests.conftest import RedisBook, RedisLibrary
-from tests.utils import insert_test_data, load_fixture
+from tests.utils import load_fixture
 
 _LIBRARY_DATA = load_fixture("libraries.json")
 _TEST_ADDRESS = "Hoima, Uganda"

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -40,6 +40,17 @@ async def test_find_mongo_style(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("index", range(4))
+async def test_regex_find_mongo_style(redis_store, regex_params_redis, index):
+    """Find with regex should find the items that match the regex"""
+    filters, expected = regex_params_redis[index]
+    with pytest.raises(
+        NotImplementedError, match=r"redis text search is too inexpressive for regex."
+    ):
+        await redis_store.find(RedisLibrary, query=filters)
+
+
+@pytest.mark.asyncio
 async def test_find_hybrid(redis_store, inserted_redis_libs):
     """Find should return the items that match the mongodb-like filter AND the native filter"""
     got = await redis_store.find(

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -38,6 +38,15 @@ async def test_find_mongo_style(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("index", range(4))
+async def test_regex_find_mongo_style(sql_store, regex_params_sql, index):
+    """Find with regex should find the items that match the regex"""
+    filters, expected = regex_params_sql[index]
+    got = await sql_store.find(SqlLibrary, query=filters)
+    assert got == expected
+
+
+@pytest.mark.asyncio
 async def test_find_hybrid(sql_store, inserted_sql_libs):
     """Find should return the items that match the mongodb-like filter AND the native filter"""
     got = await sql_store.find(

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -20,7 +20,7 @@ async def test_find_native(sql_store, inserted_sql_libs):
         for v in inserted_sql_libs
         if v.address == _TEST_ADDRESS or v.name.startswith("Ba")
     ][1:]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -34,7 +34,7 @@ async def test_find_mongo_style(sql_store, inserted_sql_libs):
     expected = [
         v for v in inserted_sql_libs if v.address == _TEST_ADDRESS or v.name == "Bar"
     ][1:]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -43,7 +43,7 @@ async def test_regex_find_mongo_style(sql_store, regex_params_sql, index):
     """Find with regex should find the items that match the regex"""
     filters, expected = regex_params_sql[index]
     got = await sql_store.find(SqlLibrary, query=filters)
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -60,7 +60,7 @@ async def test_find_hybrid(sql_store, inserted_sql_libs):
         for v in inserted_sql_libs
         if v.address == _TEST_ADDRESS and v.name.startswith("Ba")
     ][1:]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -71,7 +71,7 @@ async def test_create(sql_store):
     expected = [
         SqlLibrary(id=idx + 1, **item) for idx, item in enumerate(_LIBRARY_DATA)
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -92,7 +92,7 @@ async def test_update_native(sql_store, inserted_sql_libs):
         for record in inserted_sql_libs
         if matches_query(record)
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
     # all library data in database
     got = await sql_store.find(SqlLibrary)
@@ -100,7 +100,7 @@ async def test_update_native(sql_store, inserted_sql_libs):
         (record.model_copy(update=updates) if matches_query(record) else record)
         for record in inserted_sql_libs
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -127,7 +127,7 @@ async def test_update_mongo_style(sql_store, inserted_sql_libs):
         if matches_query(record)
     ]
 
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
     # all library data in database
     got = await sql_store.find(SqlLibrary)
@@ -135,7 +135,7 @@ async def test_update_mongo_style(sql_store, inserted_sql_libs):
         (record.model_copy(update=updates) if matches_query(record) else record)
         for record in inserted_sql_libs
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -157,7 +157,7 @@ async def test_update_hybrid(sql_store, inserted_sql_libs):
         for record in inserted_sql_libs
         if matches_query(record)
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
     # all library data in database
     got = await sql_store.find(SqlLibrary)
@@ -165,7 +165,7 @@ async def test_update_hybrid(sql_store, inserted_sql_libs):
         (record.model_copy(update=updates) if matches_query(record) else record)
         for record in inserted_sql_libs
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -175,12 +175,12 @@ async def test_delete_native(sql_store, inserted_sql_libs):
     # NOTE: redis startswith/contains on single letters is not supported by redis
     got = await sql_store.delete(SqlLibrary, SqlLibrary.name.startswith("bu"))
     expected = [v for v in inserted_sql_libs if v.name.lower().startswith("bu")]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
     # all data in database
     got = await sql_store.find(SqlLibrary)
     expected = [v for v in inserted_sql_libs if not v.name.lower().startswith("bu")]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -205,7 +205,7 @@ async def test_delete_mongo_style(sql_store, inserted_sql_libs):
         for v in inserted_sql_libs
         if v.address in addresses or v.name not in unwanted_names
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
     # all data in database
     got = await sql_store.find(SqlLibrary)
@@ -214,7 +214,7 @@ async def test_delete_mongo_style(sql_store, inserted_sql_libs):
         for v in inserted_sql_libs
         if v.address not in addresses and v.name in unwanted_names
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -234,7 +234,7 @@ async def test_delete_hybrid(sql_store, inserted_sql_libs):
         for v in inserted_sql_libs
         if v.address not in unwanted_addresses and v.name.lower().startswith("bu")
     ]
-    assert got == expected
+    assert _ordered(got) == _ordered(expected)
 
     # all data in database
     got = await sql_store.find(SqlLibrary)
@@ -244,3 +244,15 @@ async def test_delete_hybrid(sql_store, inserted_sql_libs):
         if v.address in unwanted_addresses or not v.name.lower().startswith("bu")
     ]
     assert got == expected
+
+
+def _ordered(libs: list[SqlLibrary]) -> list[SqlLibrary]:
+    """Sorts the libraries by id and returns them
+
+    Args:
+        libs: the library instances to sort
+
+    Returns:
+        the ordered libraries
+    """
+    return sorted(libs, key=lambda v: v.id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,5 @@
 import json
+import re
 from os import path
 from typing import Any, TypeVar
 
@@ -71,3 +72,32 @@ def to_sql_text(model: type[SQLModel], queries: tuple[_SQLFilter, ...]) -> str:
     """
     sql = select(model).where(*queries)
     return str(sql.compile())
+
+
+def get_regex_test_params(libs: list[_LibType]) -> list[tuple[dict, list[_LibType]]]:
+    """Generates the test params for the REGEX test for the given libs
+
+    Args:
+        libs: the Library records
+
+    Returns:
+        pairs of regex filter and expected output after querying
+    """
+    return [
+        (
+            {"name": {"$regex": "^bu.*", "$options": "i"}},
+            [v for v in libs if re.match(r"^bu.*", v.name, re.I)],
+        ),
+        (
+            {"name": {"$regex": "^bu.*"}},
+            [v for v in libs if re.match(r"^bu.*", v.name)],
+        ),
+        (
+            {"name": {"$regex": "am.*"}},
+            [v for v in libs if re.match(r".*am.*", v.name)],
+        ),
+        (
+            {"name": {"$regex": ".*i$"}},
+            [v for v in libs if re.match(r".*i$", v.name)],
+        ),
+    ]


### PR DESCRIPTION
### Why

To make the API easier to use

### What was Done

- Added regex support for SQL
- Enabled defining schemas once to be shared by different database technologies
- Disabled direct imports from `nqlstore.mongo`, `nqlstore.sql`, `nqlstore.redis`