### PR TITLE
Bump to v0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.2] - 2025-02-06
+
 ### Added
 
 - Added regex support for SQL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nqlstore"
 authors = [
     {name = "Martin Ahindura", email = "sales@sopherapps.com"},
 ]
-version = "0.0.1"
+version = "0.0.2"
 description = "NQLStore, a simple CRUD store python library for `any query launguage` (or in short `nql`)."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Changelog

### Added

- Added regex support for SQL

### Changed

- Allowed update dicts without operators in mongo update implementation
- Enabled defining schemas once to be shared by different database technologies
- Disabled direct imports from `nqlstore.mongo`, `nqlstore.sql`, `nqlstore.redis`