### PR TITLE
Hotfix/model type annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        extra: ["all,test", "sql,test", "redis,test", "mongo,test"]
 
     services:
       mongodb:
@@ -50,11 +51,11 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Install dependencies
+      - name: Install dependencies [${{ matrix.extra }}]
         run: |
           python -m pip install --upgrade pip
           python --version
-          pip install ."[test,sql,mongo,redis]"
+          pip install ."[${{ matrix.extra }}]"
       - name: Lint with black
         run: black --check .
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,11 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# environments
+senv/
+renv/
+menv/
+
+# pyenv
+.python-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Type annotations for `SQLModel`, `MongoModel`, `JsonModel`, `HashModel` and `EmbeddedJsonModel`
+
 ## [0.0.2] - 2025-02-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Changed Github actions to run tests for each extra plus the `test` extra i.e. `[sql,test]`, `[redis,test]` etc. 
+
 ### Fixed
 
 - Fixed Type annotations for `SQLModel`, `MongoModel`, `JsonModel`, `HashModel` and `EmbeddedJsonModel`
+- Fixed import errors when only `sql` or `redis` or `mongo` extras are installed.
 
 ## [0.0.2] - 2025-02-06
 

--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ libraries = await redis_store.delete(
 ## TODO
 
 - [ ] Implement dot notation for embedded documents and arrays (i.e. relationships in SQL)
+- [ ] Fix import errors when extras except `all` are installed
 - [ ] Add documentation site
 - [ ] Add example applications
 

--- a/nqlstore/_compat.py
+++ b/nqlstore/_compat.py
@@ -13,10 +13,12 @@ try:
     from aredis_om import RedisModel as _RedisModel
     from aredis_om import get_redis_connection
     from aredis_om.model.model import Expression
+    from aredis_om.model.model import Field as _RedisField
     from aredis_om.model.model import FieldInfo as _RedisFieldInfo
     from aredis_om.model.model import VectorFieldOptions, verify_pipeline_response
     from redis.client import Pipeline
 except ImportError:
+    from pydantic.fields import Field as _RedisField
     from pydantic.fields import FieldInfo as _RedisFieldInfo
     from pydantic.main import BaseModel
 
@@ -47,6 +49,7 @@ try:
     from sqlmodel._compat import post_init_field_info
     from sqlmodel.ext.asyncio.session import AsyncSession
     from sqlmodel.main import Column
+    from sqlmodel.main import Field as _SQLField
     from sqlmodel.main import FieldInfo as _SqlFieldInfo
     from sqlmodel.main import NoArgAnyCallable, OnDeleteType, Relationship
 except ImportError:
@@ -55,6 +58,7 @@ except ImportError:
 
     from pydantic import BaseModel as _SQLModel
     from pydantic.fields import Field as Relationship
+    from pydantic.fields import Field as _SQLField
     from pydantic.fields import FieldInfo as _FieldInfo
 
     class _SqlFieldInfo(_FieldInfo): ...

--- a/nqlstore/_compat.py
+++ b/nqlstore/_compat.py
@@ -1,0 +1,98 @@
+"""Module to cater for missing dependencies"""
+
+from typing import Any, Callable, Literal
+
+"""
+redis imports; and their defaults if redis_om is missing
+"""
+try:
+    from aredis_om import EmbeddedJsonModel as _EmbeddedJsonModel
+    from aredis_om import HashModel as _HashModel
+    from aredis_om import JsonModel as _JsonModel
+    from aredis_om import KNNExpression, Migrator
+    from aredis_om import RedisModel as _RedisModel
+    from aredis_om import get_redis_connection
+    from aredis_om.model.model import Expression
+    from aredis_om.model.model import FieldInfo as _RedisFieldInfo
+    from aredis_om.model.model import VectorFieldOptions, verify_pipeline_response
+    from redis.client import Pipeline
+except ImportError:
+    from pydantic.fields import FieldInfo as _RedisFieldInfo
+    from pydantic.main import BaseModel
+
+    VectorFieldOptions = Any
+    _EmbeddedJsonModel = BaseModel
+    _HashModel = BaseModel
+    _JsonModel = BaseModel
+    _RedisModel = BaseModel
+    KNNExpression = Any
+    Expression = Any
+    Pipeline = Any
+    Migrator = lambda *a, **k: dict(**k)
+    get_redis_connection = lambda *a, **k: dict(**k)
+    verify_pipeline_response = lambda *a, **k: dict(**k)
+
+
+"""
+sql imports; and their default if sqlmodel is missing
+"""
+try:
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlalchemy.sql._typing import (
+        _ColumnExpressionArgument,
+        _ColumnExpressionOrStrLabelArgument,
+    )
+    from sqlmodel import SQLModel as _SQLModel
+    from sqlmodel import delete, insert, select, update
+    from sqlmodel._compat import post_init_field_info
+    from sqlmodel.ext.asyncio.session import AsyncSession
+    from sqlmodel.main import Column
+    from sqlmodel.main import FieldInfo as _SqlFieldInfo
+    from sqlmodel.main import NoArgAnyCallable, OnDeleteType, Relationship
+except ImportError:
+    from typing import Set as _ColumnExpressionArgument
+    from typing import Set as _ColumnExpressionOrStrLabelArgument
+
+    from pydantic import BaseModel as _SQLModel
+    from pydantic.fields import Field as Relationship
+    from pydantic.fields import FieldInfo as _FieldInfo
+
+    class _SqlFieldInfo(_FieldInfo): ...
+
+    post_init_field_info = lambda b: b
+    NoArgAnyCallable = Callable[[], Any]
+    OnDeleteType = Literal["CASCADE", "SET NULL", "RESTRICT"]
+    Column = Any
+    create_async_engine = lambda *a, **k: dict(**k)
+    delete = insert = select = update = create_async_engine
+    AsyncSession = Any
+
+
+"""
+mongo imports; and their defaults if the 'beanie' package is not installed
+"""
+try:
+    from beanie import (
+        BulkWriter,
+        Document,
+        PydanticObjectId,
+        SortDirection,
+        WriteRules,
+        init_beanie,
+    )
+    from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession
+except ImportError:
+    from pydantic import BaseModel as Document
+
+    init_beanie = lambda *a, **k: dict(**k)
+    BulkWriter = Any
+    SortDirection = Any
+    AsyncIOMotorClient = lambda *a, **k: dict(**k)
+    AsyncIOMotorClientSession = Any
+    PydanticObjectId = Any
+
+    import enum
+
+    class WriteRules(str, enum.Enum):
+        DO_NOTHING = "DO_NOTHING"
+        WRITE = "WRITE"

--- a/nqlstore/_field.py
+++ b/nqlstore/_field.py
@@ -3,7 +3,9 @@
 from typing import (
     AbstractSet,
     Any,
+    Callable,
     Dict,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -12,18 +14,31 @@ from typing import (
     overload,
 )
 
-from aredis_om.model.model import FieldInfo as _RedisFieldInfo
-from aredis_om.model.model import VectorFieldOptions
-from sqlmodel._compat import post_init_field_info
-from sqlmodel.main import Column
-from sqlmodel.main import FieldInfo as _SqlFieldInfo
-from sqlmodel.main import (
-    NoArgAnyCallable,
-    OnDeleteType,
-    Relationship,
-    Undefined,
-    UndefinedType,
-)
+from pydantic_core import PydanticUndefined as Undefined
+from pydantic_core import PydanticUndefinedType as UndefinedType
+
+# redis imports
+try:
+    from aredis_om.model.model import FieldInfo as _RedisFieldInfo
+    from aredis_om.model.model import VectorFieldOptions
+except ImportError:
+    from pydantic.fields import FieldInfo as _RedisFieldInfo
+
+    VectorFieldOptions = Any
+
+# sql imports
+try:
+    from sqlmodel._compat import post_init_field_info
+    from sqlmodel.main import Column
+    from sqlmodel.main import FieldInfo as _SqlFieldInfo
+    from sqlmodel.main import NoArgAnyCallable, OnDeleteType, Relationship
+except ImportError:
+    from pydantic.fields import FieldInfo as _SqlFieldInfo
+
+    post_init_field_info = lambda b: b
+    NoArgAnyCallable = Callable[[], Any]
+    OnDeleteType = Literal["CASCADE", "SET NULL", "RESTRICT"]
+    Column = Any
 
 
 class FieldInfo(_SqlFieldInfo, _RedisFieldInfo):
@@ -36,7 +51,7 @@ class FieldInfo(_SqlFieldInfo, _RedisFieldInfo):
 def Field(
     default: Any = Undefined,
     *,
-    default_factory: Optional[NoArgAnyCallable] = None,
+    default_factory: Optional["NoArgAnyCallable"] = None,
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
@@ -74,7 +89,7 @@ def Field(
     sortable: Union[bool, UndefinedType] = Undefined,
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
-    vector_options: Optional[VectorFieldOptions] = None,
+    vector_options: Optional["VectorFieldOptions"] = None,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 
@@ -85,7 +100,7 @@ def Field(
 def Field(
     default: Any = Undefined,
     *,
-    default_factory: Optional[NoArgAnyCallable] = None,
+    default_factory: Optional["NoArgAnyCallable"] = None,
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
@@ -124,7 +139,7 @@ def Field(
     sortable: Union[bool, UndefinedType] = Undefined,
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
-    vector_options: Optional[VectorFieldOptions] = None,
+    vector_options: Optional["VectorFieldOptions"] = None,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 
@@ -143,7 +158,7 @@ def Field(
 def Field(
     default: Any = Undefined,
     *,
-    default_factory: Optional[NoArgAnyCallable] = None,
+    default_factory: Optional["NoArgAnyCallable"] = None,
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
@@ -170,11 +185,11 @@ def Field(
     regex: Optional[str] = None,
     discriminator: Optional[str] = None,
     repr: bool = True,
-    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
+    sa_column: Union["Column", UndefinedType] = Undefined,  # type: ignore
     sortable: Union[bool, UndefinedType] = Undefined,
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
-    vector_options: Optional[VectorFieldOptions] = None,
+    vector_options: Optional["VectorFieldOptions"] = None,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 
@@ -182,7 +197,7 @@ def Field(
 def Field(
     default: Any = Undefined,
     *,
-    default_factory: Optional[NoArgAnyCallable] = None,
+    default_factory: Optional["NoArgAnyCallable"] = None,
     alias: Optional[str] = None,
     title: Optional[str] = None,
     description: Optional[str] = None,
@@ -216,13 +231,13 @@ def Field(
     nullable: Union[bool, UndefinedType] = Undefined,
     index: Union[bool, UndefinedType] = Undefined,
     sa_type: Union[Type[Any], UndefinedType] = Undefined,
-    sa_column: Union[Column, UndefinedType] = Undefined,  # type: ignore
+    sa_column: Union["Column", UndefinedType] = Undefined,  # type: ignore
     sa_column_args: Union[Sequence[Any], UndefinedType] = Undefined,
     sa_column_kwargs: Union[Mapping[str, Any], UndefinedType] = Undefined,
     sortable: Union[bool, UndefinedType] = Undefined,
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
-    vector_options: Optional[VectorFieldOptions] = None,
+    vector_options: Optional["VectorFieldOptions"] = None,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any:
     current_schema_extra = schema_extra or {}

--- a/nqlstore/_field.py
+++ b/nqlstore/_field.py
@@ -33,7 +33,10 @@ try:
     from sqlmodel.main import FieldInfo as _SqlFieldInfo
     from sqlmodel.main import NoArgAnyCallable, OnDeleteType, Relationship
 except ImportError:
-    from pydantic.fields import FieldInfo as _SqlFieldInfo
+    from pydantic.fields import Field as Relationship
+    from pydantic.fields import FieldInfo as _FieldInfo
+
+    class _SqlFieldInfo(_FieldInfo): ...
 
     post_init_field_info = lambda b: b
     NoArgAnyCallable = Callable[[], Any]

--- a/nqlstore/_field.py
+++ b/nqlstore/_field.py
@@ -3,9 +3,7 @@
 from typing import (
     AbstractSet,
     Any,
-    Callable,
     Dict,
-    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -17,31 +15,16 @@ from typing import (
 from pydantic_core import PydanticUndefined as Undefined
 from pydantic_core import PydanticUndefinedType as UndefinedType
 
-# redis imports
-try:
-    from aredis_om.model.model import FieldInfo as _RedisFieldInfo
-    from aredis_om.model.model import VectorFieldOptions
-except ImportError:
-    from pydantic.fields import FieldInfo as _RedisFieldInfo
-
-    VectorFieldOptions = Any
-
-# sql imports
-try:
-    from sqlmodel._compat import post_init_field_info
-    from sqlmodel.main import Column
-    from sqlmodel.main import FieldInfo as _SqlFieldInfo
-    from sqlmodel.main import NoArgAnyCallable, OnDeleteType, Relationship
-except ImportError:
-    from pydantic.fields import Field as Relationship
-    from pydantic.fields import FieldInfo as _FieldInfo
-
-    class _SqlFieldInfo(_FieldInfo): ...
-
-    post_init_field_info = lambda b: b
-    NoArgAnyCallable = Callable[[], Any]
-    OnDeleteType = Literal["CASCADE", "SET NULL", "RESTRICT"]
-    Column = Any
+from ._compat import (
+    Column,
+    NoArgAnyCallable,
+    OnDeleteType,
+    Relationship,
+    VectorFieldOptions,
+    _RedisFieldInfo,
+    _SqlFieldInfo,
+    post_init_field_info,
+)
 
 
 class FieldInfo(_SqlFieldInfo, _RedisFieldInfo):

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -7,34 +7,17 @@ from pydantic import BaseModel
 from pydantic import Field as _Field
 from pydantic.main import ModelT, create_model
 
-from nqlstore._base import BaseStore
-
-# mongo imports
-try:
-    from beanie import (
-        BulkWriter,
-        Document,
-        PydanticObjectId,
-        SortDirection,
-        WriteRules,
-        init_beanie,
-    )
-    from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession
-except ImportError:
-    Document = BaseModel
-    init_beanie = lambda *a, **k: dict(**k)
-    BulkWriter = Any
-    SortDirection = Any
-    AsyncIOMotorClient = lambda *a, **k: dict(**k)
-    AsyncIOMotorClientSession = Any
-    PydanticObjectId = Any
-
-    import enum
-
-    class WriteRules(str, enum.Enum):
-        DO_NOTHING = "DO_NOTHING"
-        WRITE = "WRITE"
-
+from ._base import BaseStore
+from ._compat import (
+    AsyncIOMotorClient,
+    AsyncIOMotorClientSession,
+    BulkWriter,
+    Document,
+    PydanticObjectId,
+    SortDirection,
+    WriteRules,
+    init_beanie,
+)
 
 _T = TypeVar("_T", bound=Document)
 _Filter = Mapping[str, Any] | bool

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -3,13 +3,31 @@
 import re
 from typing import Any, Iterable, Mapping, TypeVar
 
-from beanie import *
-from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession
 from pydantic import BaseModel
 from pydantic import Field as _Field
 from pydantic.main import ModelT, create_model
 
 from nqlstore._base import BaseStore
+
+# mongo imports
+try:
+    from beanie import Document, PydanticObjectId, WriteRules, init_beanie
+    from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession
+except ImportError:
+    Document = BaseModel
+    init_beanie = lambda *a, **k: dict(**k)
+    BulkWriter = Any
+    SortDirection = Any
+    AsyncIOMotorClient = lambda *a, **k: dict(**k)
+    AsyncIOMotorClientSession = Any
+    PydanticObjectId = Any
+
+    import enum
+
+    class WriteRules(str, enum.Enum):
+        DO_NOTHING = "DO_NOTHING"
+        WRITE = "WRITE"
+
 
 _T = TypeVar("_T", bound=Document)
 _Filter = Mapping[str, Any] | bool

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -11,7 +11,14 @@ from nqlstore._base import BaseStore
 
 # mongo imports
 try:
-    from beanie import Document, PydanticObjectId, WriteRules, init_beanie
+    from beanie import (
+        BulkWriter,
+        Document,
+        PydanticObjectId,
+        SortDirection,
+        WriteRules,
+        init_beanie,
+    )
     from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession
 except ImportError:
     Document = BaseModel

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -162,7 +162,7 @@ class MongoStore(BaseStore):
         return deleted_items
 
 
-def MongoModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
+def MongoModel(name: str, schema: type[ModelT], /) -> type[Document]:
     """Creates a new Mongo Model for the given schema
 
     A new model can be defined by::

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -114,7 +114,7 @@ class RedisStore(BaseStore):
         return matched_items
 
 
-def HashModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
+def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel]:
     """Creates a new HashModel for the given schema for redis
 
     A new model can be defined by::
@@ -144,7 +144,7 @@ def HashModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
     )
 
 
-def JsonModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
+def JsonModel(name: str, schema: type[ModelT], /) -> type[_JsonModel]:
     """Creates a new JsonModel for the given schema for redis
 
     A new model can be defined by::
@@ -174,7 +174,7 @@ def JsonModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
     )
 
 
-def EmbeddedJsonModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
+def EmbeddedJsonModel(name: str, schema: type[ModelT], /) -> type[_EmbeddedJsonModel]:
     """Creates a new EmbeddedJsonModel for the given schema for redis
 
     A new model can be defined by::

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -2,34 +2,23 @@
 
 from typing import Any, Callable, Iterable, TypeVar
 
-from pydantic.main import BaseModel, ModelT, create_model
+from pydantic.main import ModelT, create_model
 
-from nqlstore._base import BaseStore
-from nqlstore.query.parsers import QueryParser
-from nqlstore.query.selectors import QuerySelector
-
-# redis imports
-try:
-    from aredis_om import EmbeddedJsonModel as _EmbeddedJsonModel
-    from aredis_om import HashModel as _HashModel
-    from aredis_om import JsonModel as _JsonModel
-    from aredis_om import KNNExpression, Migrator
-    from aredis_om import RedisModel as _RedisModel
-    from aredis_om import get_redis_connection
-    from aredis_om.model.model import Expression, verify_pipeline_response
-    from redis.client import Pipeline
-except ImportError:
-    _EmbeddedJsonModel = BaseModel
-    _HashModel = BaseModel
-    _JsonModel = BaseModel
-    _RedisModel = BaseModel
-    KNNExpression = Any
-    Expression = Any
-    Pipeline = Any
-    Migrator = lambda *a, **k: dict(**k)
-    get_redis_connection = lambda *a, **k: dict(**k)
-    verify_pipeline_response = lambda *a, **k: dict(**k)
-
+from ._base import BaseStore
+from ._compat import (
+    Expression,
+    KNNExpression,
+    Migrator,
+    Pipeline,
+    _EmbeddedJsonModel,
+    _HashModel,
+    _JsonModel,
+    _RedisModel,
+    get_redis_connection,
+    verify_pipeline_response,
+)
+from .query.parsers import QueryParser
+from .query.selectors import QuerySelector
 
 _T = TypeVar("_T", bound=_RedisModel)
 

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -2,19 +2,34 @@
 
 from typing import Any, Callable, Iterable, TypeVar
 
-from aredis_om import EmbeddedJsonModel as _EmbeddedJsonModel
-from aredis_om import HashModel as _HashModel
-from aredis_om import JsonModel as _JsonModel
-from aredis_om import KNNExpression, Migrator
-from aredis_om import RedisModel as _RedisModel
-from aredis_om import get_redis_connection
-from aredis_om.model.model import Expression, verify_pipeline_response
-from pydantic.main import ModelT, create_model
-from redis.client import Pipeline
+from pydantic.main import BaseModel, ModelT, create_model
 
 from nqlstore._base import BaseStore
 from nqlstore.query.parsers import QueryParser
 from nqlstore.query.selectors import QuerySelector
+
+# redis imports
+try:
+    from aredis_om import EmbeddedJsonModel as _EmbeddedJsonModel
+    from aredis_om import HashModel as _HashModel
+    from aredis_om import JsonModel as _JsonModel
+    from aredis_om import KNNExpression, Migrator
+    from aredis_om import RedisModel as _RedisModel
+    from aredis_om import get_redis_connection
+    from aredis_om.model.model import Expression, verify_pipeline_response
+    from redis.client import Pipeline
+except ImportError:
+    _EmbeddedJsonModel = BaseModel
+    _HashModel = BaseModel
+    _JsonModel = BaseModel
+    _RedisModel = BaseModel
+    KNNExpression = Any
+    Expression = Any
+    Pipeline = Any
+    Migrator = lambda *a, **k: dict(**k)
+    get_redis_connection = lambda *a, **k: dict(**k)
+    verify_pipeline_response = lambda *a, **k: dict(**k)
+
 
 _T = TypeVar("_T", bound=_RedisModel)
 

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -4,19 +4,32 @@ from typing import Any, Iterable, TypeVar
 
 from pydantic import create_model
 from pydantic.main import ModelT
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy.sql._typing import (
-    _ColumnExpressionArgument,
-    _ColumnExpressionOrStrLabelArgument,
-)
-from sqlmodel import SQLModel as _SQLModel
-from sqlmodel import delete, insert, select, update
-from sqlmodel.ext.asyncio.session import AsyncSession
 
 from ._base import BaseStore
 from ._field import Field
 from .query.parsers import QueryParser
 from .query.selectors import QuerySelector
+
+# sql imports
+try:
+    from sqlalchemy.ext.asyncio import create_async_engine
+    from sqlalchemy.sql._typing import (
+        _ColumnExpressionArgument,
+        _ColumnExpressionOrStrLabelArgument,
+    )
+    from sqlmodel import SQLModel as _SQLModel
+    from sqlmodel import delete, insert, select, update
+    from sqlmodel.ext.asyncio.session import AsyncSession
+except ImportError:
+    from typing import Set as _ColumnExpressionArgument
+    from typing import Set as _ColumnExpressionOrStrLabelArgument
+
+    from pydantic import BaseModel as _SQLModel
+
+    create_async_engine = lambda *a, **k: dict(**k)
+    delete = insert = select = update = create_async_engine
+    AsyncSession = Any
+
 
 _T = TypeVar("_T", bound=_SQLModel)
 _Filter = _ColumnExpressionArgument[bool] | bool

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -6,30 +6,20 @@ from pydantic import create_model
 from pydantic.main import ModelT
 
 from ._base import BaseStore
+from ._compat import (
+    AsyncSession,
+    _ColumnExpressionArgument,
+    _ColumnExpressionOrStrLabelArgument,
+    _SQLModel,
+    create_async_engine,
+    delete,
+    insert,
+    select,
+    update,
+)
 from ._field import Field
 from .query.parsers import QueryParser
 from .query.selectors import QuerySelector
-
-# sql imports
-try:
-    from sqlalchemy.ext.asyncio import create_async_engine
-    from sqlalchemy.sql._typing import (
-        _ColumnExpressionArgument,
-        _ColumnExpressionOrStrLabelArgument,
-    )
-    from sqlmodel import SQLModel as _SQLModel
-    from sqlmodel import delete, insert, select, update
-    from sqlmodel.ext.asyncio.session import AsyncSession
-except ImportError:
-    from typing import Set as _ColumnExpressionArgument
-    from typing import Set as _ColumnExpressionOrStrLabelArgument
-
-    from pydantic import BaseModel as _SQLModel
-
-    create_async_engine = lambda *a, **k: dict(**k)
-    delete = insert = select = update = create_async_engine
-    AsyncSession = Any
-
 
 _T = TypeVar("_T", bound=_SQLModel)
 _Filter = _ColumnExpressionArgument[bool] | bool

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -122,7 +122,7 @@ class _SQLModelMeta(_SQLModel):
     id: int | None = Field(default=None, primary_key=True)
 
 
-def SQLModel(name: str, schema: type[ModelT], /) -> type[ModelT]:
+def SQLModel(name: str, schema: type[ModelT], /) -> type[_SQLModel]:
     """Creates a new SQLModel for the given schema for redis
 
     A new model can be defined by::

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,26 +37,25 @@ class Book(BaseModel, Generic[_T]):
         name = "books"
 
 
+# default models
+SqlLibrary = Library
+SqlBook = Book[int]
+MongoLibrary = Library
+MongoBook = Book[str]
+RedisLibrary = Library
+RedisBook = Book[str]
+
 if is_lib_installed("sqlmodel"):
     SqlLibrary = SQLModel("SqlLibrary", Library)
     SqlBook = SQLModel("SqlBook", Book[int])
-else:
-    SqlLibrary = Library
-    SqlBook = Book[int]
 
 if is_lib_installed("beanie"):
     MongoLibrary = MongoModel("MongoLibrary", Library)
     MongoBook = MongoModel("MongoBook", Book[PydanticObjectId])
-else:
-    MongoLibrary = Library
-    MongoBook = Book[str]
 
 if is_lib_installed("redis_om"):
     RedisLibrary = HashModel("RedisLibrary", Library)
     RedisBook = HashModel("RedisBook", Book[str])
-else:
-    RedisLibrary = Library
-    RedisBook = Book[str]
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 from typing import Generic, TypeVar
 
-import pymongo
 import pytest
 import pytest_asyncio
-import redis
 from pydantic import BaseModel
 
 from nqlstore import (
@@ -18,7 +16,7 @@ from nqlstore import (
 )
 from nqlstore.query.parsers import QueryParser
 
-from .utils import get_regex_test_params, insert_test_data
+from .utils import get_regex_test_params, insert_test_data, is_lib_installed
 
 _T = TypeVar("_T")
 
@@ -39,15 +37,30 @@ class Book(BaseModel, Generic[_T]):
         name = "books"
 
 
-MongoLibrary = MongoModel("MongoLibrary", Library)
-MongoBook = MongoModel("MongoBook", Book[PydanticObjectId])
-RedisLibrary = HashModel("RedisLibrary", Library)
-RedisBook = HashModel("RedisBook", Book[str])
-SqlLibrary = SQLModel("SqlLibrary", Library)
-SqlBook = SQLModel("SqlBook", Book[int])
+if is_lib_installed("sqlmodel"):
+    SqlLibrary = SQLModel("SqlLibrary", Library)
+    SqlBook = SQLModel("SqlBook", Book[int])
+else:
+    SqlLibrary = Library
+    SqlBook = Book[int]
+
+if is_lib_installed("beanie"):
+    MongoLibrary = MongoModel("MongoLibrary", Library)
+    MongoBook = MongoModel("MongoBook", Book[PydanticObjectId])
+else:
+    MongoLibrary = Library
+    MongoBook = Book[str]
+
+if is_lib_installed("redis_om"):
+    RedisLibrary = HashModel("RedisLibrary", Library)
+    RedisBook = HashModel("RedisBook", Book[str])
+else:
+    RedisLibrary = Library
+    RedisBook = Book[str]
 
 
 @pytest.fixture
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 def sql_store():
     """The sql store stored in memory"""
     store = SQLStore(uri="sqlite+aiosqlite:///:memory:")
@@ -55,8 +68,11 @@ def sql_store():
 
 
 @pytest.fixture
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 def mongo_store():
     """The mongodb store"""
+    import pymongo
+
     store = MongoStore(uri="mongodb://localhost:27017", database="testing")
     yield store
 
@@ -66,8 +82,11 @@ def mongo_store():
 
 
 @pytest.fixture
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 def redis_store():
     """The redis store"""
+    import redis
+
     store = RedisStore(uri="redis://localhost:6379/0")
     yield store
 
@@ -77,6 +96,7 @@ def redis_store():
 
 
 @pytest_asyncio.fixture()
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def inserted_redis_libs(redis_store):
     """The libraries inserted in the redis store"""
     inserted_libs, _ = await insert_test_data(
@@ -86,12 +106,14 @@ async def inserted_redis_libs(redis_store):
 
 
 @pytest.fixture
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 def regex_params_redis(inserted_redis_libs):
     """The regex test params for redis"""
     yield get_regex_test_params(inserted_redis_libs)
 
 
 @pytest_asyncio.fixture()
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def inserted_mongo_libs(mongo_store):
     """The libraries inserted in the mongodb store"""
     inserted_libs, _ = await insert_test_data(
@@ -101,12 +123,14 @@ async def inserted_mongo_libs(mongo_store):
 
 
 @pytest.fixture
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 def regex_params_mongo(inserted_mongo_libs):
     """The regex test params for mongo"""
     yield get_regex_test_params(inserted_mongo_libs)
 
 
 @pytest_asyncio.fixture()
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def inserted_sql_libs(sql_store):
     """The libraries inserted in the sql store"""
     inserted_libs, _ = await insert_test_data(
@@ -116,19 +140,31 @@ async def inserted_sql_libs(sql_store):
 
 
 @pytest.fixture
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 def regex_params_sql(inserted_sql_libs):
     """The regex test params for sql"""
     yield get_regex_test_params(inserted_sql_libs)
 
 
 @pytest_asyncio.fixture()
-async def query_parser():
-    """The default query parser"""
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+async def sql_qparser():
+    """The default query parser for sql"""
+    qparser = QueryParser()
+    sql_store = SQLStore(uri="sqlite+aiosqlite:///:memory:", parser=qparser)
+    await sql_store.register([SqlLibrary, SqlBook])
+    yield qparser
+
+
+@pytest_asyncio.fixture()
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+async def redis_qparser():
+    """The default query parser for redis"""
+    import redis
+
     qparser = QueryParser()
     redis_store = RedisStore(uri="redis://localhost:6379/0", parser=qparser)
-    sql_store = SQLStore(uri="sqlite+aiosqlite:///:memory:", parser=qparser)
     await redis_store.register([RedisLibrary, RedisBook])
-    await sql_store.register([SqlLibrary, SqlBook])
 
     yield qparser
 

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -3,12 +3,13 @@ import re
 import pytest
 
 from tests.conftest import MongoBook, MongoLibrary
-from tests.utils import load_fixture
+from tests.utils import is_lib_installed, load_fixture
 
 _LIBRARY_DATA = load_fixture("libraries.json")
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def test_find(mongo_store, inserted_mongo_libs):
     """Find should find the items that match the filter"""
     got = await mongo_store.find(MongoLibrary, {}, skip=1)
@@ -17,6 +18,7 @@ async def test_find(mongo_store, inserted_mongo_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 @pytest.mark.parametrize("index", range(4))
 async def test_regex_find(mongo_store, regex_params_mongo, index):
     """Find with regex should find the items that match the regex"""
@@ -26,6 +28,7 @@ async def test_regex_find(mongo_store, regex_params_mongo, index):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def test_create(mongo_store):
     """Create should add many items to the mongo database"""
     await mongo_store.register([MongoLibrary, MongoBook])
@@ -35,6 +38,7 @@ async def test_create(mongo_store):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def test_update(mongo_store, inserted_mongo_libs):
     """Update should update the items that match the filter"""
     updates = {"address": "some new address"}
@@ -56,6 +60,7 @@ async def test_update(mongo_store, inserted_mongo_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def test_update_native(mongo_store, inserted_mongo_libs):
     """Update should update the items that match the filter with mongo-style update operators"""
     updates = {"$set": {"address": "some new address"}}
@@ -77,6 +82,7 @@ async def test_update_native(mongo_store, inserted_mongo_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def test_delete(mongo_store, inserted_mongo_libs):
     """Delete should remove the items that match the filter"""
     # in immediate response

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,145 +1,166 @@
 """Tests for the query package"""
 
+import pytest
+
 from tests.conftest import RedisLibrary, SqlLibrary
-from tests.utils import to_sql_text
+from tests.utils import is_lib_installed, to_sql_text
 
 
-def test_eq_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_eq_redis(redis_qparser):
     """$eq checks equality in redis"""
     query = {"name": {"$eq": "Hoima, Uganda"}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name == "Hoima, Uganda"),)
 
 
-def test_eq_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_eq_sql(sql_qparser):
     """$eq checks equality in sql"""
     query = {"name": {"$eq": "Hoima, Uganda"}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name == "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_gt_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_gt_redis(redis_qparser):
     """$gt checks greater than in redis"""
     query = {"name": {"$gt": "Hoima, Uganda"}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name > "Hoima, Uganda"),)
 
 
-def test_gt_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_gt_sql(sql_qparser):
     """$gt checks greater than in sql"""
     query = {"name": {"$gt": "Hoima, Uganda"}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name > "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_gte_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_gte_redis(redis_qparser):
     """$gte checks greater or equal in redis"""
     query = {"name": {"$gte": "Hoima, Uganda"}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name >= "Hoima, Uganda"),)
 
 
-def test_gte_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_gte_sql(sql_qparser):
     """$gte checks greater or equal in sql"""
     query = {"name": {"$gte": "Hoima, Uganda"}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name >= "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_in_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_in_redis(redis_qparser):
     """$in checks value in list in redis"""
     query = {"name": {"$in": ["Hoima, Uganda"]}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name << ["Hoima, Uganda"]),)
 
 
-def test_in_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_in_sql(sql_qparser):
     """$in checks vlue in list than in sql"""
     query = {"name": {"$in": ["Hoima, Uganda"]}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name.in_(["Hoima, Uganda"])),))
     assert got == expected
 
 
-def test_lt_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_lt_redis(redis_qparser):
     """$lt checks less than in redis"""
     query = {"name": {"$lt": "Hoima, Uganda"}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name < "Hoima, Uganda"),)
 
 
-def test_lt_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_lt_sql(sql_qparser):
     """$lt checks less than in sql"""
     query = {"name": {"$lt": "Hoima, Uganda"}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name < "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_lte_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_lte_redis(redis_qparser):
     """$lt checks less or equal in redis"""
     query = {"name": {"$lte": "Hoima, Uganda"}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name <= "Hoima, Uganda"),)
 
 
-def test_lte_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_lte_sql(sql_qparser):
     """$lt checks less or equal in sql"""
     query = {"name": {"$lte": "Hoima, Uganda"}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name <= "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_ne_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_ne_redis(redis_qparser):
     """$ne checks not equal in redis"""
     query = {"name": {"$ne": "Hoima, Uganda"}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name != "Hoima, Uganda"),)
 
 
-def test_ne_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_ne_sql(sql_qparser):
     """$ne checks not equal in sql"""
     query = {"name": {"$ne": "Hoima, Uganda"}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name != "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_nin_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_nin_redis(redis_qparser):
     """$nin checks not in in redis"""
     query = {"name": {"$nin": ["Hoima, Uganda"]}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == ((RedisLibrary.name >> ["Hoima, Uganda"]),)
 
 
-def test_nin_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_nin_sql(sql_qparser):
     """$nin checks not in in sql"""
     query = {"name": {"$nin": ["Hoima, Uganda"]}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, ((SqlLibrary.name.not_in(["Hoima, Uganda"])),))
     assert got == expected
 
 
-def test_not_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_not_redis(redis_qparser):
     """$not checks not in redis"""
     query = {"name": {"$not": {"$lt": "Hoima, Uganda"}}}
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == (~(RedisLibrary.name < "Hoima, Uganda"),)
 
 
-def test_not_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_not_sql(sql_qparser):
     """$not checks not in sql"""
     query = {"name": {"$not": {"$lt": "Hoima, Uganda"}}}
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(SqlLibrary, (~(SqlLibrary.name < "Hoima, Uganda"),))
     assert got == expected
 
 
-def test_and_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_and_redis(redis_qparser):
     """$and checks all conditions fulfilled in redis"""
     query = {
         "$and": [
@@ -147,14 +168,15 @@ def test_and_redis(query_parser):
             {"$or": [{"address": {"$eq": "Bar"}}, {"name": {"$gt": "Buliisa"}}]},
         ]
     }
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == (
         (RedisLibrary.name < "Hoima, Uganda")
         & ((RedisLibrary.address == "Bar") | (RedisLibrary.name > "Buliisa")),
     )
 
 
-def test_and_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_and_sql(sql_qparser):
     """$and checks all conditions fulfilled in sql"""
     query = {
         "$and": [
@@ -162,7 +184,7 @@ def test_and_sql(query_parser):
             {"$or": [{"address": {"$eq": "Bar"}}, {"name": {"$gt": "Buliisa"}}]},
         ]
     }
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(
         SqlLibrary,
         (
@@ -173,7 +195,8 @@ def test_and_sql(query_parser):
     assert got == expected
 
 
-def test_or_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_or_redis(redis_qparser):
     """$or checks any condition fulfilled in redis"""
     query = {
         "$or": [
@@ -181,14 +204,15 @@ def test_or_redis(query_parser):
             {"$and": [{"address": {"$eq": "Bar"}}, {"name": {"$gt": "Buliisa"}}]},
         ]
     }
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == (
         (RedisLibrary.name < "Hoima, Uganda")
         | ((RedisLibrary.address == "Bar") & (RedisLibrary.name > "Buliisa")),
     )
 
 
-def test_or_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_or_sql(sql_qparser):
     """$or checks any condition fulfilled in sql"""
     query = {
         "$or": [
@@ -196,7 +220,7 @@ def test_or_sql(query_parser):
             {"$and": [{"address": {"$eq": "Bar"}}, {"name": {"$gt": "Buliisa"}}]},
         ]
     }
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(
         SqlLibrary,
         (
@@ -207,7 +231,8 @@ def test_or_sql(query_parser):
     assert got == expected
 
 
-def test_nor_redis(query_parser):
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+def test_nor_redis(redis_qparser):
     """$nor checks none of the conditions is fulfilled in redis"""
     query = {
         "$nor": [
@@ -215,14 +240,15 @@ def test_nor_redis(query_parser):
             {"$or": [{"address": {"$eq": "Bar"}}, {"name": {"$gt": "Buliisa"}}]},
         ]
     }
-    got = query_parser.to_redis(RedisLibrary, query)
+    got = redis_qparser.to_redis(RedisLibrary, query)
     assert got == (
         ~(RedisLibrary.name < "Hoima, Uganda")
         & ~((RedisLibrary.address == "Bar") | (RedisLibrary.name > "Buliisa")),
     )
 
 
-def test_nor_sql(query_parser):
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+def test_nor_sql(sql_qparser):
     """$and checks none of the conditions is fulfilled in sql"""
     query = {
         "$nor": [
@@ -230,7 +256,7 @@ def test_nor_sql(query_parser):
             {"$or": [{"address": {"$eq": "Bar"}}, {"name": {"$gt": "Buliisa"}}]},
         ]
     }
-    got = to_sql_text(SqlLibrary, query_parser.to_sql(SqlLibrary, query))
+    got = to_sql_text(SqlLibrary, sql_qparser.to_sql(SqlLibrary, query))
     expected = to_sql_text(
         SqlLibrary,
         (

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -1,13 +1,14 @@
 import pytest
 
 from tests.conftest import RedisBook, RedisLibrary
-from tests.utils import load_fixture
+from tests.utils import is_lib_installed, load_fixture
 
 _LIBRARY_DATA = load_fixture("libraries.json")
 _TEST_ADDRESS = "Hoima, Uganda"
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_find_native(redis_store, inserted_redis_libs):
     """Find should return the items that match the native filter"""
     got = await redis_store.find(
@@ -24,6 +25,7 @@ async def test_find_native(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_find_mongo_style(redis_store, inserted_redis_libs):
     """Find should return the items that match the mongodb-like filter"""
     got = await redis_store.find(
@@ -40,6 +42,7 @@ async def test_find_mongo_style(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 @pytest.mark.parametrize("index", range(4))
 async def test_regex_find_mongo_style(redis_store, regex_params_redis, index):
     """Find with regex should find the items that match the regex"""
@@ -51,6 +54,7 @@ async def test_regex_find_mongo_style(redis_store, regex_params_redis, index):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_find_hybrid(redis_store, inserted_redis_libs):
     """Find should return the items that match the mongodb-like filter AND the native filter"""
     got = await redis_store.find(
@@ -68,6 +72,7 @@ async def test_find_hybrid(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_create(redis_store):
     """Create should add many items to the sql database"""
     await redis_store.register([RedisLibrary, RedisBook])
@@ -77,6 +82,7 @@ async def test_create(redis_store):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_update_native(redis_store, inserted_redis_libs):
     """Update should update the items that match the native filter"""
     updates = {"address": "some new address"}
@@ -106,6 +112,7 @@ async def test_update_native(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_update_mongo_style(redis_store, inserted_redis_libs):
     """Update should update the items that match the mongodb-like filter"""
     updates = {"address": "some new address"}
@@ -140,6 +147,7 @@ async def test_update_mongo_style(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_update_hybrid(redis_store, inserted_redis_libs):
     """Update should update the items that match the mongodb-like filter AND the native filter"""
     updates = {"address": "some new address"}
@@ -170,6 +178,7 @@ async def test_update_hybrid(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_delete_native(redis_store, inserted_redis_libs):
     """Delete should delete the items that match the native filter"""
     # in immediate response
@@ -185,6 +194,7 @@ async def test_delete_native(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_delete_mongo_style(redis_store, inserted_redis_libs):
     """Delete should delete the items that match the mongodb-like filter"""
     addresses = ["Bujumbura, Burundi", "Non existent"]
@@ -219,6 +229,7 @@ async def test_delete_mongo_style(redis_store, inserted_redis_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_delete_hybrid(redis_store, inserted_redis_libs):
     """Delete should delete the items that match the mongodb-like filter AND the native filter"""
     unwanted_addresses = ["Stockholm, Sweden"]

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -1,13 +1,14 @@
 import pytest
 
 from tests.conftest import SqlBook, SqlLibrary
-from tests.utils import load_fixture
+from tests.utils import is_lib_installed, load_fixture
 
 _LIBRARY_DATA = load_fixture("libraries.json")
 _TEST_ADDRESS = "Hoima, Uganda"
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_find_native(sql_store, inserted_sql_libs):
     """Find should return the items that match the native filter"""
     got = await sql_store.find(
@@ -24,6 +25,7 @@ async def test_find_native(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_find_mongo_style(sql_store, inserted_sql_libs):
     """Find should return the items that match the mongodb-like filter"""
     got = await sql_store.find(
@@ -38,6 +40,7 @@ async def test_find_mongo_style(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 @pytest.mark.parametrize("index", range(4))
 async def test_regex_find_mongo_style(sql_store, regex_params_sql, index):
     """Find with regex should find the items that match the regex"""
@@ -47,6 +50,7 @@ async def test_regex_find_mongo_style(sql_store, regex_params_sql, index):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_find_hybrid(sql_store, inserted_sql_libs):
     """Find should return the items that match the mongodb-like filter AND the native filter"""
     got = await sql_store.find(
@@ -64,6 +68,7 @@ async def test_find_hybrid(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_create(sql_store):
     """Create should add many items to the sql database"""
     await sql_store.register([SqlLibrary, SqlBook])
@@ -75,6 +80,7 @@ async def test_create(sql_store):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_update_native(sql_store, inserted_sql_libs):
     """Update should update the items that match the native filter"""
     updates = {"address": "some new address"}
@@ -104,6 +110,7 @@ async def test_update_native(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_update_mongo_style(sql_store, inserted_sql_libs):
     """Update should update the items that match the mongodb-like filter"""
     updates = {"address": "some new address"}
@@ -139,6 +146,7 @@ async def test_update_mongo_style(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_update_hybrid(sql_store, inserted_sql_libs):
     """Update should update the items that match the mongodb-like filter AND the native filter"""
     updates = {"address": "some new address"}
@@ -169,6 +177,7 @@ async def test_update_hybrid(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_delete_native(sql_store, inserted_sql_libs):
     """Delete should delete the items that match the native filter"""
     # in immediate response
@@ -184,6 +193,7 @@ async def test_delete_native(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_delete_mongo_style(sql_store, inserted_sql_libs):
     """Delete should delete the items that match the mongodb-like filter"""
     addresses = ["Bujumbura, Burundi", "Non existent"]
@@ -218,6 +228,7 @@ async def test_delete_mongo_style(sql_store, inserted_sql_libs):
 
 
 @pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_delete_hybrid(sql_store, inserted_sql_libs):
     """Delete should delete the items that match the mongodb-like filter AND the native filter"""
     unwanted_addresses = ["Stockholm, Sweden"]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,14 +1,25 @@
+import importlib
 import json
 import re
 from os import path
 from typing import Any, TypeVar
 
-from beanie import PydanticObjectId
 from pydantic import BaseModel
-from sqlalchemy.sql._typing import _ColumnExpressionArgument
 
 from nqlstore._base import BaseStore
 from nqlstore._sql import SQLModel, select
+
+# SQL imports
+try:
+    from sqlalchemy.sql._typing import _ColumnExpressionArgument
+except ImportError:
+    from typing import Set as _ColumnExpressionArgument
+
+# Mongo imports
+try:
+    from beanie import PydanticObjectId
+except ImportError:
+    PydanticObjectId = Any
 
 _SQLFilter = _ColumnExpressionArgument[bool] | bool
 _TESTS_FOLDER = path.dirname(path.abspath(__file__))
@@ -117,3 +128,15 @@ def get_regex_test_params(libs: list[_LibType]) -> list[tuple[dict, list[_LibTyp
             [v for v in libs if re.match(r".*i$", v.name)],
         ),
     ]
+
+
+def is_lib_installed(lib: str) -> bool:
+    """Check if a library is installed.
+
+    Args:
+        lib: the library to check
+
+    Returns:
+        True if library is installed else False
+    """
+    return importlib.util.find_spec(lib) is not None

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -7,19 +7,8 @@ from typing import Any, TypeVar
 from pydantic import BaseModel
 
 from nqlstore._base import BaseStore
+from nqlstore._compat import PydanticObjectId, _ColumnExpressionArgument
 from nqlstore._sql import SQLModel, select
-
-# SQL imports
-try:
-    from sqlalchemy.sql._typing import _ColumnExpressionArgument
-except ImportError:
-    from typing import Set as _ColumnExpressionArgument
-
-# Mongo imports
-try:
-    from beanie import PydanticObjectId
-except ImportError:
-    PydanticObjectId = Any
 
 _SQLFilter = _ColumnExpressionArgument[bool] | bool
 _TESTS_FOLDER = path.dirname(path.abspath(__file__))


### PR DESCRIPTION
### Why

- Type checkers were raising errors
- Library could only be used when it was installed with the `all` extra. Otherwise, it threw import errors.

### What was done

- Updated the return types of the Model functions e.g. `HashModel`, `MongoModel` etc.
- Fixed import errors when only one of the following extras is installed: `sql`, `redis`, `mongo`
- Updated Github actions to test for each scenario where the `test` extra is installed with any one of the extras  `sql`, `redis`, `mongo`.