### PR TITLE
Bump to v0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.0.3] - 2025-02-06
+
 ### Changed
 
 - Changed Github actions to run tests for each extra plus the `test` extra i.e. `[sql,test]`, `[redis,test]` etc. 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nqlstore"
 authors = [
     {name = "Martin Ahindura", email = "sales@sopherapps.com"},
 ]
-version = "0.0.2"
+version = "0.0.3"
 description = "NQLStore, a simple CRUD store python library for `any query launguage` (or in short `nql`)."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Changelog

### Changed

- Changed Github actions to run tests for each extra plus the `test` extra i.e. `[sql,test]`, `[redis,test]` etc. 

### Fixed

- Fixed Type annotations for `SQLModel`, `MongoModel`, `JsonModel`, `HashModel` and `EmbeddedJsonModel`
- Fixed import errors when only `sql` or `redis` or `mongo` extras are installed.
