### PR TITLE
Enhancement/dot notation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added Mongo-like Dot notation for querying SQL and redis
+
+### Changed
+
+- Added the `query` key-word parameter to the `find`, `update`, and `delete` for the mongo implementation
+  so that it is similar to the other interfaces
+- Added the `embedded_models` key-word argument on the `Model` initializers for redis and mongodb
+- Added the `relationships` key-word argument to the `Model` initializers for SQL
+
 ## [0.0.3] - 2025-02-06
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -327,7 +327,6 @@ libraries = await redis_store.delete(
 
 ## TODO
 
-- [ ] Implement dot notation for embedded documents and arrays (i.e. relationships in SQL)
 - [ ] Add documentation site
 - [ ] Add example applications
 

--- a/nqlstore/__init__.py
+++ b/nqlstore/__init__.py
@@ -1,5 +1,5 @@
 from ._field import Field, Relationship
-from ._mongo import MongoModel, MongoStore, PydanticObjectId
+from ._mongo import EmbeddedMongoModel, MongoModel, MongoStore, PydanticObjectId
 from ._redis import EmbeddedJsonModel, HashModel, JsonModel, RedisStore
 from ._sql import SQLModel, SQLStore
 from .query.parsers import QueryParser
@@ -10,6 +10,7 @@ __all__ = [
     "MongoModel",
     "MongoStore",
     "PydanticObjectId",
+    "EmbeddedMongoModel",
     "Field",
     "Relationship",
     "RedisStore",

--- a/nqlstore/_compat.py
+++ b/nqlstore/_compat.py
@@ -39,8 +39,9 @@ except ImportError:
 sql imports; and their default if sqlmodel is missing
 """
 try:
+    from sqlalchemy import Column, Table
     from sqlalchemy.ext.asyncio import create_async_engine
-    from sqlalchemy.orm import RelationshipProperty
+    from sqlalchemy.orm import InstrumentedAttribute, RelationshipProperty, subqueryload
     from sqlalchemy.sql._typing import (
         _ColumnExpressionArgument,
         _ColumnExpressionOrStrLabelArgument,
@@ -49,13 +50,13 @@ try:
     from sqlmodel import delete, insert, select, update
     from sqlmodel._compat import post_init_field_info
     from sqlmodel.ext.asyncio.session import AsyncSession
-    from sqlmodel.main import Column
     from sqlmodel.main import Field as _SQLField
     from sqlmodel.main import FieldInfo as _SqlFieldInfo
     from sqlmodel.main import NoArgAnyCallable, OnDeleteType
     from sqlmodel.main import RelationshipInfo as _RelationshipInfo
 except ImportError:
     from typing import Mapping, Optional, Sequence
+    from typing import Set
     from typing import Set as _ColumnExpressionArgument
     from typing import Set as _ColumnExpressionOrStrLabelArgument
     from typing import Union
@@ -72,7 +73,10 @@ except ImportError:
     create_async_engine = lambda *a, **k: dict(**k)
     delete = insert = select = update = create_async_engine
     AsyncSession = Any
-    RelationshipProperty = Any
+    RelationshipProperty = Set
+    Table = Set
+    InstrumentedAttribute = Set
+    subqueryload = lambda *a, **kwargs: dict(**kwargs)
 
     class _SqlFieldInfo(_FieldInfo): ...
 

--- a/nqlstore/_field.py
+++ b/nqlstore/_field.py
@@ -1,9 +1,11 @@
 """The main module containing the default types to be imported"""
 
+from copy import copy
 from typing import (
     AbstractSet,
     Any,
     Dict,
+    Literal,
     Mapping,
     Optional,
     Sequence,
@@ -12,6 +14,7 @@ from typing import (
     overload,
 )
 
+from pydantic.main import ModelT
 from pydantic_core import PydanticUndefined as Undefined
 from pydantic_core import PydanticUndefinedType as UndefinedType
 
@@ -19,9 +22,10 @@ from ._compat import (
     Column,
     NoArgAnyCallable,
     OnDeleteType,
-    Relationship,
+    RelationshipProperty,
     VectorFieldOptions,
     _RedisFieldInfo,
+    _RelationshipInfo,
     _SqlFieldInfo,
     post_init_field_info,
 )
@@ -29,7 +33,45 @@ from ._compat import (
 
 class FieldInfo(_SqlFieldInfo, _RedisFieldInfo):
     def __init__(self, default: Any = Undefined, **kwargs: Any) -> None:
+        disable_on_redis = kwargs.get("disable_on_redis", False)
+        disable_on_sql = kwargs.get("disable_on_sql", False)
+        disable_on_mongo = kwargs.get("disable_on_mongo", False)
         super().__init__(default=default, **kwargs)
+        self.disable_on_redis = disable_on_redis
+        self.disable_on_sql = disable_on_sql
+        self.disable_on_mongo = disable_on_mongo
+
+
+class RelationshipInfo(_RelationshipInfo):
+    def __init__(
+        self,
+        *,
+        back_populates: Optional[str] = None,
+        cascade_delete: Optional[bool] = False,
+        passive_deletes: Optional[Union[bool, Literal["all"]]] = False,
+        link_model: Optional[Any] = None,
+        sa_relationship: Optional[RelationshipProperty] = None,  # type: ignore
+        sa_relationship_args: Optional[Sequence[Any]] = None,
+        sa_relationship_kwargs: Optional[Mapping[str, Any]] = None,
+        **kwargs: Any,
+    ):
+        disable_on_redis = kwargs.get("disable_on_redis", False)
+        disable_on_sql = kwargs.get("disable_on_sql", False)
+        disable_on_mongo = kwargs.get("disable_on_mongo", False)
+        default = kwargs.get("default", Undefined)
+        super().__init__(
+            back_populates=back_populates,
+            cascade_delete=cascade_delete,
+            passive_deletes=passive_deletes,
+            link_model=link_model,
+            sa_relationship=sa_relationship,
+            sa_relationship_args=sa_relationship_args,
+            sa_relationship_kwargs=sa_relationship_kwargs,
+        )
+        self.disable_on_redis = disable_on_redis
+        self.disable_on_sql = disable_on_sql
+        self.disable_on_mongo = disable_on_mongo
+        self.default = default
 
 
 # include sa_type, sa_column_args, sa_column_kwargs
@@ -76,6 +118,9 @@ def Field(
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
     vector_options: Optional["VectorFieldOptions"] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 
@@ -126,6 +171,9 @@ def Field(
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
     vector_options: Optional["VectorFieldOptions"] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 
@@ -176,6 +224,9 @@ def Field(
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
     vector_options: Optional["VectorFieldOptions"] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any: ...
 
@@ -224,6 +275,9 @@ def Field(
     case_sensitive: Union[bool, UndefinedType] = Undefined,
     full_text_search: Union[bool, UndefinedType] = Undefined,
     vector_options: Optional["VectorFieldOptions"] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
     schema_extra: Optional[Dict[str, Any]] = None,
 ) -> Any:
     current_schema_extra = schema_extra or {}
@@ -266,7 +320,148 @@ def Field(
         case_sensitive=case_sensitive,
         full_text_search=full_text_search,
         vector_options=vector_options,
+        disable_on_redis=disable_on_redis,
+        disable_on_sql=disable_on_sql,
+        disable_on_mongo=disable_on_mongo,
         **current_schema_extra,
     )
     post_init_field_info(field_info)
     return field_info
+
+
+@overload
+def Relationship(
+    *,
+    back_populates: Optional[str] = None,
+    cascade_delete: Optional[bool] = False,
+    passive_deletes: Optional[Union[bool, Literal["all"]]] = False,
+    link_model: Optional[Any] = None,
+    sa_relationship_args: Optional[Sequence[Any]] = None,
+    sa_relationship_kwargs: Optional[Mapping[str, Any]] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
+    default: Any = Undefined,
+) -> Any: ...
+
+
+@overload
+def Relationship(
+    *,
+    back_populates: Optional[str] = None,
+    cascade_delete: Optional[bool] = False,
+    passive_deletes: Optional[Union[bool, Literal["all"]]] = False,
+    link_model: Optional[Any] = None,
+    sa_relationship: Optional[RelationshipProperty[Any]] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
+    default: Any = Undefined,
+) -> Any: ...
+
+
+def Relationship(
+    *,
+    back_populates: Optional[str] = None,
+    cascade_delete: Optional[bool] = False,
+    passive_deletes: Optional[Union[bool, Literal["all"]]] = False,
+    link_model: Optional[Any] = None,
+    sa_relationship: Optional[RelationshipProperty[Any]] = None,
+    sa_relationship_args: Optional[Sequence[Any]] = None,
+    sa_relationship_kwargs: Optional[Mapping[str, Any]] = None,
+    disable_on_redis: bool = False,
+    disable_on_sql: bool = False,
+    disable_on_mongo: bool = False,
+    default: Any = Undefined,
+) -> Any:
+    relationship_info = RelationshipInfo(
+        back_populates=back_populates,
+        cascade_delete=cascade_delete,
+        passive_deletes=passive_deletes,
+        link_model=link_model,
+        sa_relationship=sa_relationship,
+        sa_relationship_args=sa_relationship_args,
+        sa_relationship_kwargs=sa_relationship_kwargs,
+        disable_on_redis=disable_on_redis,
+        disable_on_sql=disable_on_sql,
+        disable_on_mongo=disable_on_mongo,
+        default=default,
+    )
+    return relationship_info
+
+
+def get_field_definitions(
+    schema: type[ModelT],
+    embedded_models: dict[str, Type] | None = None,
+    relationships: dict[str, Type] | None = None,
+    is_for_redis: bool = False,
+    is_for_mongo: bool = False,
+    is_for_sql: bool = False,
+) -> dict[str, tuple[Type[Any], FieldInfo]]:
+    """Retrieves the field definitions from the given schema and embedded models
+
+    Args:
+        schema: the model schema class
+        embedded_models: the map of embedded models as <field_name>: <type annotation>
+        relationships: the map of relationships as <field_name>: <type annotation>
+        is_for_redis: whether the definitions are for redis or not
+        is_for_mongo: whether the definitions are for mongo or not
+        is_for_sql: whether the definitions are for sql or not
+
+    Returns:
+        dict of attributes for the model in format: <name>: (<type>, <FieldInfo>)
+    """
+    if embedded_models is None:
+        embedded_models = {}
+
+    if relationships is None:
+        relationships = {}
+
+    fields = {}
+    for field_name, field in schema.model_fields.items():  # type: str, FieldInfo
+        class_field_definition = _get_class_field_definition(field)
+        if is_for_redis and class_field_definition.disable_on_redis:
+            continue
+
+        if is_for_mongo and class_field_definition.disable_on_mongo:
+            continue
+
+        if is_for_sql and class_field_definition.disable_on_sql:
+            continue
+
+        field_type = field.annotation
+        field_info = field
+
+        if field_name in embedded_models:
+            field_type = embedded_models[field_name]
+            field_info = copy(field)
+            field_info.default = class_field_definition.default
+
+        elif field_name in relationships:
+            field_type = relationships[field_name]
+            # redefine the class so that SQLModel can redo its thing
+            field_info = class_field_definition
+
+        fields[field_name] = (field_type, field_info)
+    return fields
+
+
+def _get_class_field_definition(field: FieldInfo) -> RelationshipInfo | FieldInfo:
+    """Retrieves the relationship pr field as originally defined on the class
+
+    SQLModel seems to change Relationship definitions to field definitions
+    then hiding the real Relationship in the field as the `default` value.
+    Ths function retrieves the original field definition as seen on the class definition.
+
+    Args:
+        field: the field from which to extract the relationship info
+
+    Returns:
+        the relationship info if field is relationship else it returns the field
+    """
+    try:
+        if isinstance(field.default, RelationshipInfo):
+            return field.default
+    except Exception:
+        pass
+    return field

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -48,9 +48,24 @@ class MongoStore(BaseStore):
         multiprocessing_mode: bool = False,
         skip_indexes: bool = False,
     ):
+        """Registers the given models and runs any initialization steps
+
+        Args:
+            models: the list of Model's this store is to contain
+            allow_index_dropping: if index dropping is allowed.
+                Default False
+            recreate_views: if views should be recreated. Default False
+            multiprocessing_mode: bool - if multiprocessing mode is on
+                it will patch the motor client to use process's event loop. Default False
+            skip_indexes: if you want to skip working with the indexes.
+                Default False
+        """
+        document_models = [
+            cls for cls in models if not issubclass(cls, _EmbeddedMongoModel)
+        ]
         await init_beanie(
             self._db,
-            document_models=models,
+            document_models=document_models,
             allow_index_dropping=allow_index_dropping,
             recreate_views=recreate_views,
             multiprocessing_mode=multiprocessing_mode,
@@ -185,17 +200,28 @@ class MongoStore(BaseStore):
         return deleted_items
 
 
+class _EmbeddedMongoModel(BaseModel):
+    """An embedded model for mongo database
+
+    It is never created in the database as a collection
+    """
+
+    pass
+
+
 def MongoModel(
     name: str,
     schema: type[ModelT],
     /,
-    embedded_models: dict[str, type[BaseModel] | type[list[BaseModel]]] = None,
+    embedded_models: dict[
+        str, type[_EmbeddedMongoModel] | type[list[_EmbeddedMongoModel]]
+    ] = None,
 ) -> type[Document]:
     """Creates a new Mongo Model for the given schema
 
     A new model can be defined by::
 
-        Model = MongoModel("Model", Schema)
+        Model = MongoModel("Model", Schema, embedded_models = {"address": Address})
 
     Args:
         name: the name of the model
@@ -209,11 +235,49 @@ def MongoModel(
         schema, embedded_models=embedded_models, is_for_mongo=True
     )
 
-    return create_model(
+    model = create_model(
         name,
         __doc__=schema.__doc__,
         __slots__=schema.__slots__,
         __base__=(Document,),
+        **fields,
+    )
+
+    _copy_settings(dst=model, src=schema)
+    return model
+
+
+def EmbeddedMongoModel(
+    name: str,
+    schema: type[ModelT],
+    /,
+    embedded_models: dict[
+        str, type[_EmbeddedMongoModel] | type[list[_EmbeddedMongoModel]]
+    ] = None,
+) -> type[_EmbeddedMongoModel]:
+    """Creates a new embedded Mongo Model for the given schema
+
+    A new model can be defined by::
+
+        Model = EmbeddedMongoModel("Model", Schema)
+
+    Args:
+        name: the name of the model
+        schema: the schema from which the model is to be made
+        embedded_models: a dict of embedded models of <field name>: annotation
+
+    Returns:
+        an embedded Mongo model class with the given name
+    """
+    fields = get_field_definitions(
+        schema, embedded_models=embedded_models, is_for_mongo=True
+    )
+
+    return create_model(
+        name,
+        __doc__=schema.__doc__,
+        __slots__=schema.__slots__,
+        __base__=(_EmbeddedMongoModel,),
         **fields,
     )
 
@@ -238,3 +302,17 @@ def _to_mongo_updates(updates: dict[str, Any]) -> dict[str, Any]:
             return updates
 
     return {"$set": updates}
+
+
+def _copy_settings(dst: type[Document], src: type[ModelT]):
+    """Copies settings from source to destination
+
+    Args:
+        dst: the model to receive the settings
+        src: the model or schema that contains the settings
+    """
+    try:
+        settings_cls = getattr(src, "Settings")
+        setattr(dst, "Settings", settings_cls)
+    except AttributeError:
+        pass

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -238,7 +238,6 @@ def MongoModel(
     model = create_model(
         name,
         __doc__=schema.__doc__,
-        __slots__=schema.__slots__,
         __base__=(Document,),
         **fields,
     )
@@ -276,7 +275,6 @@ def EmbeddedMongoModel(
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __slots__=schema.__slots__,
         __base__=(_EmbeddedMongoModel,),
         **fields,
     )

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -1,6 +1,6 @@
 """Redis implementation"""
 
-from typing import Any, Callable, Iterable, TypeVar
+from typing import Any, Callable, Iterable, Type, TypeVar
 
 from pydantic.main import ModelT, create_model
 
@@ -17,6 +17,7 @@ from ._compat import (
     get_redis_connection,
     verify_pipeline_response,
 )
+from ._field import get_field_definitions
 from .query.parsers import QueryParser
 from .query.selectors import QuerySelector
 
@@ -132,24 +133,28 @@ def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel]:
     Returns:
         a HashModel model class with the given name
     """
+    fields = get_field_definitions(schema, embedded_models=None, is_for_redis=True)
+
     # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
         __doc__=schema.__doc__,
         __slots__=schema.__slots__,
-        __base__=(
-            _HashModel,
-            schema,
-        ),
-        **{
-            field_name: (field.annotation, field)
-            for field_name, field in schema.model_fields.items()
-        },
+        __base__=(_HashModel,),
+        **fields,
     )
 
 
-def JsonModel(name: str, schema: type[ModelT], /) -> type[_JsonModel]:
+def JsonModel(
+    name: str,
+    schema: type[ModelT],
+    /,
+    embedded_models: dict[str, Type] = None,
+) -> type[_JsonModel]:
     """Creates a new JsonModel for the given schema for redis
+
+    Note that redis supports only single embedded objects,
+    not lists or tuples of embedded models
 
     A new model can be defined by::
 
@@ -158,23 +163,22 @@ def JsonModel(name: str, schema: type[ModelT], /) -> type[_JsonModel]:
     Args:
         name: the name of the model
         schema: the schema from which the model is to be made
+        embedded_models: a dict of embedded models of <field name>: annotation
 
     Returns:
         a JsonModel model class with the given name
     """
+    fields = get_field_definitions(
+        schema, embedded_models=embedded_models, is_for_redis=True
+    )
+
     # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
         __doc__=schema.__doc__,
         __slots__=schema.__slots__,
-        __base__=(
-            _JsonModel,
-            schema,
-        ),
-        **{
-            field_name: (field.annotation, field)
-            for field_name, field in schema.model_fields.items()
-        },
+        __base__=(_JsonModel,),
+        **fields,
     )
 
 
@@ -192,17 +196,13 @@ def EmbeddedJsonModel(name: str, schema: type[ModelT], /) -> type[_EmbeddedJsonM
     Returns:
         a EmbeddedJsonModel model class with the given name
     """
+    fields = get_field_definitions(schema, embedded_models=None, is_for_redis=True)
+
     # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
         __doc__=schema.__doc__,
         __slots__=schema.__slots__,
-        __base__=(
-            _EmbeddedJsonModel,
-            schema,
-        ),
-        **{
-            field_name: (field.annotation, field)
-            for field_name, field in schema.model_fields.items()
-        },
+        __base__=(_EmbeddedJsonModel,),
+        **fields,
     )

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -139,7 +139,6 @@ def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel]:
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __slots__=schema.__slots__,
         __base__=(_HashModel,),
         **fields,
     )
@@ -176,7 +175,6 @@ def JsonModel(
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __slots__=schema.__slots__,
         __base__=(_JsonModel,),
         **fields,
     )
@@ -202,7 +200,6 @@ def EmbeddedJsonModel(name: str, schema: type[ModelT], /) -> type[_EmbeddedJsonM
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __slots__=schema.__slots__,
         __base__=(_EmbeddedJsonModel,),
         **fields,
     )

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -5,11 +5,7 @@ from typing import Any, Iterable, TypeVar, Union
 from pydantic import create_model
 from pydantic.main import ModelT
 from sqlalchemy import Column, Table
-from sqlalchemy.orm import (
-    InstrumentedAttribute,
-    RelationshipProperty,
-    subqueryload,
-)
+from sqlalchemy.orm import InstrumentedAttribute, RelationshipProperty, subqueryload
 
 from ._base import BaseStore
 from ._compat import (
@@ -207,7 +203,6 @@ def SQLModel(
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __slots__=schema.__slots__,
         __cls_kwargs__={"table": True},
         __base__=(_SQLModelMeta,),
         **fields,
@@ -324,4 +319,4 @@ def _to_subquery_based_filters(
         subquery = subquery.join_from(model, rel)
 
     # return a filter checking model id against the returned ids
-    return [model.id.in_(subquery.where(*rel_filters).subquery())]
+    return [model.id.in_(subquery.where(*rel_filters))]

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -4,13 +4,10 @@ from typing import Any, Iterable, TypeVar, Union
 
 from pydantic import create_model
 from pydantic.main import ModelT
-from sqlalchemy import Column, Executable, Table, inspect
+from sqlalchemy import Column, Table
 from sqlalchemy.orm import (
-    InspectionAttr,
     InstrumentedAttribute,
     RelationshipProperty,
-    contains_eager,
-    joinedload,
     subqueryload,
 )
 
@@ -26,12 +23,11 @@ from ._compat import (
     select,
     update,
 )
-from ._field import Field, FieldInfo, RelationshipInfo, get_field_definitions
+from ._field import Field, get_field_definitions
 from .query.parsers import QueryParser
 from .query.selectors import QuerySelector
 
 _T = TypeVar("_T", bound=_SQLModel)
-_T_stmt = TypeVar("_T_stmt", bound=Executable)
 _Filter = _ColumnExpressionArgument[bool] | bool
 
 
@@ -78,23 +74,31 @@ class SQLStore(BaseStore):
 
             # eagerly load all relationships so that no validation errors occur due
             # to missing session if there is an attempt to load them lazily later
-            options = [subqueryload(v) for v in relations]
+            eager_load_opts = [subqueryload(v) for v in relations]
 
-            stmt = (
-                _apply_joins(
-                    model,
-                    statement=select(model),
-                    relations=relations,
-                    filters=filters,
-                )
-                .options(*options)
+            filtered_relations = _get_filtered_relations(
+                filters=filters,
+                relations=relations,
+            )
+
+            # Note that we need to treat relations that are referenced in the filters
+            # differently from those that are not. This is because filtering basing on a relationship
+            # requires the use of an inner join. Yet an inner join automatically excludes rows
+            # that are have null for a given relationship.
+            #
+            # An outer join on the other hand would just return all the rows in the left table.
+            # We thus need to do an inner join on tables that are being filtered.
+            stmt = select(model)
+            for rel in filtered_relations:
+                stmt = stmt.join_from(model, rel)
+
+            cursor = await session.stream_scalars(
+                stmt.options(*eager_load_opts)
                 .where(*filters)
                 .limit(limit)
                 .offset(skip)
                 .order_by(*sort)
             )
-
-            cursor = await session.stream_scalars(stmt)
             results = await cursor.all()
             return list(results)
 
@@ -110,12 +114,25 @@ class SQLStore(BaseStore):
             if query:
                 filters = (*filters, *self._parser.to_sql(model, query=query))
 
+            # Construct filters that have sub queries
+            relations = _get_relations(model)
+            rel_filters, non_rel_filters = _sieve_rel_from_non_rel_filters(
+                filters=filters,
+                relations=relations,
+            )
+            rel_filters = _to_subquery_based_filters(
+                model=model,
+                rel_filters=rel_filters,
+                relations=relations,
+            )
+
             stmt = (
                 update(model)
-                .where(*filters)
+                .where(*non_rel_filters, *rel_filters)
                 .values(**updates)
                 .returning(model.__table__)
             )
+
             cursor = await session.stream(stmt)
             results = await cursor.fetchall()
             await session.commit()
@@ -129,12 +146,29 @@ class SQLStore(BaseStore):
         **kwargs,
     ) -> list[_T]:
         async with AsyncSession(self._engine) as session:
-            nql_filters = ()
             if query:
-                nql_filters = self._parser.to_sql(model, query=query)
+                filters = (*filters, *self._parser.to_sql(model, query=query))
+
+            # Construct filters that have sub queries
+            relations = _get_relations(model)
+            rel_filters, non_rel_filters = _sieve_rel_from_non_rel_filters(
+                filters=filters,
+                relations=relations,
+            )
+            rel_filters = _to_subquery_based_filters(
+                model=model,
+                rel_filters=rel_filters,
+                relations=relations,
+            )
+            exec_options = {}
+            if len(rel_filters) > 0:
+                exec_options = {"is_delete_using": True}
 
             cursor = await session.stream(
-                delete(model).where(*filters, *nql_filters).returning(model.__table__)
+                delete(model)
+                .where(*non_rel_filters, *rel_filters)
+                .returning(model.__table__)
+                .execution_options(**exec_options),
             )
             results = await cursor.all()
             await session.commit()
@@ -196,7 +230,7 @@ def _get_relations(model: type[_SQLModel]):
     ]
 
 
-def _get_filtered_tables(filters: tuple[_Filter, ...]) -> list[Table]:
+def _get_filtered_tables(filters: Iterable[_Filter]) -> list[Table]:
     """Retrieves the tables that have been referenced in the filters
 
     Args:
@@ -213,38 +247,81 @@ def _get_filtered_tables(filters: tuple[_Filter, ...]) -> list[Table]:
     ]
 
 
-def _apply_joins(
-    model: type[_SQLModel],
-    statement: _T_stmt,
-    relations: list[InstrumentedAttribute[Any]],
-    filters: tuple[_Filter, ...],
-) -> _T_stmt:
-    """Adds join statements to the statement given the relations and the filters
-
-    Note: this changes the stmt in-place
+def _get_filtered_relations(
+    filters: Iterable[_Filter], relations: Iterable[InstrumentedAttribute[Any]]
+) -> list[InstrumentedAttribute[Any]]:
+    """Retrieves the relations that have been referenced in the filters
 
     Args:
-        model: the SQLModel class for the given query/mutation
-        statement: the executable statement to execute on the session
-        relations: the list of relationship fields that this model has
-        filters: the tuple of expressions that are being used to match the records in database
+        filters: the tuple of filters to inspect
+        relations: all relations present on the model
 
     Returns:
-        the executable statement with the joins applied
+        the list of relations referenced in the filters
     """
     filtered_tables = _get_filtered_tables(filters)
-    filtered_relations = [
-        rel for rel in relations if rel.property.target in filtered_tables
-    ]
+    return [rel for rel in relations if rel.property.target in filtered_tables]
 
-    # Note that we need to treat relations that are referenced in the filters
-    # differently from those that are not. This is because filtering basing on a relationship
-    # requires the use of an inner join. Yet an inner join automatically excludes rows
-    # that are have null for a given relationship.
-    #
-    # An outer join on the other hand would just return all the rows in the left table.
-    # We thus need to do an inner join on tables that are being filtered.
+
+def _sieve_rel_from_non_rel_filters(
+    filters: Iterable[_Filter], relations: Iterable[InstrumentedAttribute[Any]]
+) -> tuple[list[_Filter], list[_Filter]]:
+    """Separates relational filters from non-relational ones
+
+    Args:
+        filters: the tuple of filters to inspect
+        relations: all relations present on the model
+
+    Returns:
+        tuple(rel, non_rel) where rel = list of relational filters,
+            and non_rel = non-relational filters
+    """
+    rel_targets = [v.property.target for v in relations]
+    rel = []
+    non_rel = []
+
+    for filter_ in filters:
+        operands = filter_.get_children()
+        if any([getattr(v, "table", None) in rel_targets for v in operands]):
+            rel.append(filter_)
+        else:
+            non_rel.append(filter_)
+
+    return rel, non_rel
+
+
+def _to_subquery_based_filters(
+    model: type[_SQLModel],
+    rel_filters: list[_Filter],
+    relations: Iterable[InstrumentedAttribute[Any]],
+) -> list[_Filter]:
+    """Converts filters to those that use subqueries to connect to other models
+
+    This is especially important for update() and delete() which do not
+    don't have `.join()` methods on them.
+
+    Args:
+        model: the model for which the subquery-based filters are to be generated
+        rel_filters: the filters that have relationships in them
+        relations: the relationship fields on the model
+
+    Returns:
+        list of filters that use subqueries to access other tables/models
+    """
+    # This is based on:
+    # https://docs.sqlalchemy.org/en/20/orm/queryguide/dml.html#update-delete-with-custom-where-criteria-for-joined-table-inheritance
+    if len(rel_filters) == 0:
+        return []
+
+    filtered_relations = _get_filtered_relations(
+        filters=rel_filters,
+        relations=relations,
+    )
+
+    # create the subquery collecting ids of model, with inner join to related models
+    subquery = select(model.id)
     for rel in filtered_relations:
-        statement = statement.join_from(model, rel)
+        subquery = subquery.join_from(model, rel)
 
-    return statement
+    # return a filter checking model id against the returned ids
+    return [model.id.in_(subquery.where(*rel_filters).subquery())]

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -5,7 +5,7 @@ from typing import Any, Iterable, TypeVar, Union
 from pydantic import create_model
 from pydantic.main import ModelT
 from sqlalchemy import inspect
-from sqlalchemy.orm import joinedload, subqueryload
+from sqlalchemy.orm import joinedload
 
 from ._base import BaseStore
 from ._compat import (
@@ -69,9 +69,7 @@ class SQLStore(BaseStore):
 
             # eagerly load all relationships so that no validation errors occur due
             # to missing session if there is an attempt to load them lazily later
-            rel_options = [
-                subqueryload(v) for v in inspect(model).relationships.values()
-            ]
+            rel_options = [joinedload(v) for v in inspect(model).relationships.values()]
 
             cursor = await session.stream_scalars(
                 select(model)
@@ -81,7 +79,7 @@ class SQLStore(BaseStore):
                 .order_by(*sort)
                 .options(*rel_options)
             )
-            results = await cursor.all()
+            results = await cursor.unique().all()
             return list(results)
 
     async def update(

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -4,12 +4,14 @@ from typing import Any, Iterable, TypeVar, Union
 
 from pydantic import create_model
 from pydantic.main import ModelT
-from sqlalchemy import Column, Table
-from sqlalchemy.orm import InstrumentedAttribute, RelationshipProperty, subqueryload
 
 from ._base import BaseStore
 from ._compat import (
     AsyncSession,
+    Column,
+    InstrumentedAttribute,
+    RelationshipProperty,
+    Table,
     _ColumnExpressionArgument,
     _ColumnExpressionOrStrLabelArgument,
     _SQLModel,
@@ -17,6 +19,7 @@ from ._compat import (
     delete,
     insert,
     select,
+    subqueryload,
     update,
 )
 from ._field import Field, get_field_definitions

--- a/nqlstore/query/parsers.py
+++ b/nqlstore/query/parsers.py
@@ -13,6 +13,7 @@ from .._compat import (
     _SQLField,
     _SQLModel,
 )
+from .._field import RelationshipInfo
 from .selectors import OperatorSelector, QuerySelector
 
 _SQLFilter = _ColumnExpressionArgument[bool] | bool
@@ -130,7 +131,9 @@ class FieldPredicate(QueryPredicate):
         **kwargs,
     ):
         if __sql_model__:
-            self.__sql_field__ = getattr(__sql_model__, selector)
+            self.__sql_field__ = _get_sql_nested_field(
+                model=__sql_model__, path=selector
+            )
 
         if __redis_model__:
             self.__redis_field__ = getattr(__redis_model__, selector)
@@ -748,3 +751,37 @@ def _redis_or(__filters: list[_RedisFilter]) -> _RedisFilter:
         the merged OR filter
     """
     return reduce(lambda prev, curr: prev | curr, __filters)
+
+
+def _get_sql_nested_field(model: type[_SQLModel], path: str) -> _SQLField:
+    """Retrieves the SQLField at the given path, which may or may not be dotted
+
+    Args:
+        path: the path to the field where dots signify relations; example books.title
+        model: the parent model
+
+    Returns:
+        the SQLField at the given path
+
+    Raises:
+        ValueError: no field '{path}' found on '{parent}'
+    """
+    path_segments = path.split(".")
+    current_parent = model
+
+    field = None
+    for idx, part in enumerate(path_segments):
+        field = getattr(current_parent, part)
+        try:
+            field_property = getattr(field, "property")
+            property_mapper = getattr(field_property, "mapper")
+            current_parent = getattr(property_mapper, "class_")
+        except AttributeError as exp:
+            if idx == len(path_segments) - 1:
+                break
+            raise exp
+
+    if field is None:
+        raise ValueError(f"no field '{path}' found on '{model}'")
+
+    return field

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,12 +4,11 @@ from pydantic import BaseModel
 
 from nqlstore import (
     EmbeddedJsonModel,
+    EmbeddedMongoModel,
     Field,
-    HashModel,
     JsonModel,
     MongoModel,
     MongoStore,
-    PydanticObjectId,
     RedisStore,
     Relationship,
     SQLModel,
@@ -46,6 +45,7 @@ class Book(BaseModel):
 SqlLibrary = Library
 SqlBook = Book
 MongoLibrary = Library
+MongoBook = Book
 RedisLibrary = Library
 RedisBook = Book
 
@@ -56,8 +56,9 @@ if is_lib_installed("sqlmodel"):
     SqlBook = SQLModel("SqlBook", Book, relationships={"library": SqlLibrary | None})
 
 if is_lib_installed("beanie"):
+    MongoBook = EmbeddedMongoModel("MongoBook", Book)
     MongoLibrary = MongoModel(
-        "MongoLibrary", Library, embedded_models={"books": list[Book]}
+        "MongoLibrary", Library, embedded_models={"books": list[MongoBook]}
     )
 
 if is_lib_installed("redis_om"):
@@ -128,7 +129,10 @@ def regex_params_redis(inserted_redis_libs):
 async def inserted_mongo_libs(mongo_store):
     """The libraries inserted in the mongodb store"""
     inserted_libs, _ = await insert_test_data(
-        mongo_store, library_model=MongoLibrary, book_model=Book, is_book_embedded=True
+        mongo_store,
+        library_model=MongoLibrary,
+        book_model=MongoBook,
+        is_book_embedded=True,
     )
     yield inserted_libs
 

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -1,8 +1,8 @@
 import re
 
 import pytest
-from redis.commands.search.document import Document
 
+from nqlstore._compat import Document
 from tests.conftest import MongoBook, MongoLibrary
 from tests.utils import is_lib_installed, load_fixture
 

--- a/tests/test_mongo.py
+++ b/tests/test_mongo.py
@@ -63,7 +63,7 @@ async def test_create(mongo_store):
     books = [MongoBook(**v) for v in _BOOK_DATA]
     lib_data = [{**v, "books": [*books]} for v in _LIBRARY_DATA]
     got = await mongo_store.insert(MongoLibrary, lib_data)
-    got = [v.dict(exclude={"id"}) for v in got]
+    got = [v.model_dump(exclude={"id"}) for v in got]
     expected = [{**v, "books": [*_BOOK_DATA]} for v in _LIBRARY_DATA]
     assert got == expected
 

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -26,6 +26,22 @@ async def test_find_native(redis_store, inserted_redis_libs):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
+async def test_find_dot_notation(redis_store, inserted_redis_libs):
+    """Find should find the items that match the filter with embedded objects"""
+    wanted_titles = ["Belljar", "Benediction man"]
+    got = await redis_store.find(
+        RedisLibrary, query={"books.title": {"$in": wanted_titles}}
+    )
+    expected = [
+        v
+        for v in inserted_redis_libs
+        if any([bk.title in wanted_titles for bk in v.books])
+    ]
+    assert got == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def test_find_mongo_style(redis_store, inserted_redis_libs):
     """Find should return the items that match the mongodb-like filter"""
     got = await redis_store.find(

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -41,6 +41,22 @@ async def test_find_mongo_style(sql_store, inserted_sql_libs):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+async def test_find_dot_notation(sql_store, inserted_sql_libs):
+    """Find should find the items that match the filter with embedded objects"""
+    wanted_titles = ["Belljar", "Benediction man"]
+    got = await sql_store.find(
+        SqlLibrary, query={"books.title": {"$in": wanted_titles}}
+    )
+    expected = [
+        v
+        for v in inserted_sql_libs
+        if any([bk.title in wanted_titles for bk in v.books])
+    ]
+    assert got == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 @pytest.mark.parametrize("index", range(4))
 async def test_regex_find_mongo_style(sql_store, regex_params_sql, index):
     """Find with regex should find the items that match the regex"""

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -47,11 +47,7 @@ async def test_find_dot_notation(sql_store, inserted_sql_libs):
     got = await sql_store.find(
         SqlLibrary, query={"books.title": {"$in": wanted_titles}}
     )
-    expected = [
-        v
-        for v in inserted_sql_libs
-        if any([bk.title in wanted_titles for bk in v.books])
-    ]
+    expected = await sql_store.find(SqlLibrary, SqlBook.title.in_(wanted_titles))
     assert got == expected
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -45,13 +45,12 @@ async def test_find_dot_notation(sql_store, inserted_sql_libs):
     """Find should find the items that match the filter with embedded objects"""
     wanted_titles = ["Belljar", "Benediction man"]
     matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
-    all_libs = await sql_store.find(SqlLibrary, query={})
 
     got = await sql_store.find(
         SqlLibrary, query={"books.title": {"$in": wanted_titles}}
     )
 
-    expected = [record.model_copy() for record in all_libs if matches_query(record)]
+    expected = [v for v in inserted_sql_libs if matches_query(v)]
     assert _ordered(got) == _ordered(expected)
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -198,7 +198,6 @@ async def test_update_dot_notation(sql_store, inserted_sql_libs):
     wanted_titles = ["Belljar", "Benediction man"]
     updates = {"address": "some new address"}
     matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
-    all_libs = await sql_store.find(SqlLibrary, query={})
 
     got = await sql_store.update(
         SqlLibrary,
@@ -207,7 +206,7 @@ async def test_update_dot_notation(sql_store, inserted_sql_libs):
     )
     expected = [
         record.model_copy(update=updates)
-        for record in all_libs
+        for record in inserted_sql_libs
         if matches_query(record)
     ]
     assert _ordered(got) == _ordered(expected)
@@ -216,7 +215,7 @@ async def test_update_dot_notation(sql_store, inserted_sql_libs):
     got = await sql_store.find(SqlLibrary)
     expected = [
         (record.model_copy(update=updates) if matches_query(record) else record)
-        for record in all_libs
+        for record in inserted_sql_libs
     ]
     assert _ordered(got) == _ordered(expected)
 
@@ -307,24 +306,18 @@ async def test_delete_hybrid(sql_store, inserted_sql_libs):
 async def test_delete_dot_notation(sql_store, inserted_sql_libs):
     """Delete should delete the items that match the filter with embedded objects"""
     wanted_titles = ["Belljar", "Benediction man"]
-    updates = {"address": "some new address"}
     matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
-    all_libs = await sql_store.find(SqlLibrary, query={})
 
     got = await sql_store.delete(
         SqlLibrary,
         query={"books.title": {"$in": wanted_titles}},
     )
-    expected = [
-        record.model_copy(update=updates)
-        for record in all_libs
-        if matches_query(record)
-    ]
+    expected = [record for record in inserted_sql_libs if matches_query(record)]
     assert _ordered(got) == _ordered(expected)
 
     # all library data in database
     got = await sql_store.find(SqlLibrary)
-    expected = [record for record in all_libs if matches_query(record)]
+    expected = [record for record in inserted_sql_libs if not matches_query(record)]
     assert _ordered(got) == _ordered(expected)
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -44,11 +44,15 @@ async def test_find_mongo_style(sql_store, inserted_sql_libs):
 async def test_find_dot_notation(sql_store, inserted_sql_libs):
     """Find should find the items that match the filter with embedded objects"""
     wanted_titles = ["Belljar", "Benediction man"]
+    matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
+    all_libs = await sql_store.find(SqlLibrary, query={})
+
     got = await sql_store.find(
         SqlLibrary, query={"books.title": {"$in": wanted_titles}}
     )
-    expected = await sql_store.find(SqlLibrary, SqlBook.title.in_(wanted_titles))
-    assert got == expected
+
+    expected = [record.model_copy() for record in all_libs if matches_query(record)]
+    assert _ordered(got) == _ordered(expected)
 
 
 @pytest.mark.asyncio
@@ -190,6 +194,36 @@ async def test_update_hybrid(sql_store, inserted_sql_libs):
 
 @pytest.mark.asyncio
 @pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+async def test_update_dot_notation(sql_store, inserted_sql_libs):
+    """Update should update the items that match the filter with embedded objects"""
+    wanted_titles = ["Belljar", "Benediction man"]
+    updates = {"address": "some new address"}
+    matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
+    all_libs = await sql_store.find(SqlLibrary, query={})
+
+    got = await sql_store.update(
+        SqlLibrary,
+        query={"books.title": {"$in": wanted_titles}},
+        updates=updates,
+    )
+    expected = [
+        record.model_copy(update=updates)
+        for record in all_libs
+        if matches_query(record)
+    ]
+    assert _ordered(got) == _ordered(expected)
+
+    # all library data in database
+    got = await sql_store.find(SqlLibrary)
+    expected = [
+        (record.model_copy(update=updates) if matches_query(record) else record)
+        for record in all_libs
+    ]
+    assert _ordered(got) == _ordered(expected)
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_delete_native(sql_store, inserted_sql_libs):
     """Delete should delete the items that match the native filter"""
     # in immediate response
@@ -267,6 +301,32 @@ async def test_delete_hybrid(sql_store, inserted_sql_libs):
         if v.address in unwanted_addresses or not v.name.lower().startswith("bu")
     ]
     assert got == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
+async def test_delete_dot_notation(sql_store, inserted_sql_libs):
+    """Delete should delete the items that match the filter with embedded objects"""
+    wanted_titles = ["Belljar", "Benediction man"]
+    updates = {"address": "some new address"}
+    matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
+    all_libs = await sql_store.find(SqlLibrary, query={})
+
+    got = await sql_store.delete(
+        SqlLibrary,
+        query={"books.title": {"$in": wanted_titles}},
+    )
+    expected = [
+        record.model_copy(update=updates)
+        for record in all_libs
+        if matches_query(record)
+    ]
+    assert _ordered(got) == _ordered(expected)
+
+    # all library data in database
+    got = await sql_store.find(SqlLibrary)
+    expected = [record for record in all_libs if matches_query(record)]
+    assert _ordered(got) == _ordered(expected)
 
 
 def _ordered(libs: list[SqlLibrary]) -> list[SqlLibrary]:


### PR DESCRIPTION
### Why

Filters referring to embedded models or related tables make it easy to make queries/updates/deletes across multiple models.

### What was done

#### Added

- Added Mongo-like Dot notation for querying SQL and redis

#### Changed

- Added the `query` key-word parameter to the `find`, `update`, and `delete` for the mongo implementation
  so that it is similar to the other interfaces
- Added the `embedded_models` key-word argument on the `Model` initializers for redis and mongodb
- Added the `relationships` key-word argument to the `Model` initializers for SQL