### PR TITLE
Improve type annotations of created Models to include multi-inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Run tests
         run: |
           cd $GITHUB_WORKSPACE
-          pytest
+          pytest tests
 
   docs:
     name: Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-02-14
+
+### Changed
+
+- Improved the type annotations of the created models to show both Schema 
+  and db-specific model classes like "Document"
+
 ## [0.1.0] - 2025-02-13
 
 ### Added

--- a/nqlstore/_compat.py
+++ b/nqlstore/_compat.py
@@ -61,11 +61,12 @@ except ImportError:
     from typing import Set as _ColumnExpressionOrStrLabelArgument
     from typing import Union
 
-    from pydantic import BaseModel as _SQLModel
+    from pydantic import BaseModel
     from pydantic._internal._repr import Representation
     from pydantic.fields import Field as _SQLField
     from pydantic.fields import FieldInfo as _FieldInfo
 
+    _SQLModel = BaseModel
     post_init_field_info = lambda b: b
     NoArgAnyCallable = Callable[[], Any]
     OnDeleteType = Literal["CASCADE", "SET NULL", "RESTRICT"]
@@ -126,7 +127,7 @@ try:
     )
     from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorClientSession
 except ImportError:
-    from pydantic import BaseModel as Document
+    from pydantic import BaseModel
 
     init_beanie = lambda *a, **k: dict(**k)
     BulkWriter = Any
@@ -134,6 +135,7 @@ except ImportError:
     AsyncIOMotorClient = lambda *a, **k: dict(**k)
     AsyncIOMotorClientSession = Any
     PydanticObjectId = Any
+    Document = BaseModel
 
     import enum
 

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -216,7 +216,7 @@ def MongoModel(
     embedded_models: dict[
         str, type[_EmbeddedMongoModel] | type[list[_EmbeddedMongoModel]]
     ] = None,
-) -> type[Document]:
+) -> type[Document] | type[ModelT]:
     """Creates a new Mongo Model for the given schema
 
     A new model can be defined by::
@@ -253,7 +253,7 @@ def EmbeddedMongoModel(
     embedded_models: dict[
         str, type[_EmbeddedMongoModel] | type[list[_EmbeddedMongoModel]]
     ] = None,
-) -> type[_EmbeddedMongoModel]:
+) -> type[_EmbeddedMongoModel] | type[ModelT]:
     """Creates a new embedded Mongo Model for the given schema
 
     A new model can be defined by::

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -119,7 +119,7 @@ class RedisStore(BaseStore):
         return matched_items
 
 
-def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel]:
+def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel] | type[ModelT]:
     """Creates a new HashModel for the given schema for redis
 
     A new model can be defined by::
@@ -149,7 +149,7 @@ def JsonModel(
     schema: type[ModelT],
     /,
     embedded_models: dict[str, Type] = None,
-) -> type[_JsonModel]:
+) -> type[_JsonModel] | type[ModelT]:
     """Creates a new JsonModel for the given schema for redis
 
     Note that redis supports only single embedded objects,
@@ -180,7 +180,9 @@ def JsonModel(
     )
 
 
-def EmbeddedJsonModel(name: str, schema: type[ModelT], /) -> type[_EmbeddedJsonModel]:
+def EmbeddedJsonModel(
+    name: str, schema: type[ModelT], /
+) -> type[_EmbeddedJsonModel] | type[ModelT]:
     """Creates a new EmbeddedJsonModel for the given schema for redis
 
     A new model can be defined by::

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -185,7 +185,7 @@ def SQLModel(
     schema: type[ModelT],
     /,
     relationships: dict[str, type[Any] | type[Union[Any]]] = None,
-) -> type[_SQLModelMeta]:
+) -> type[_SQLModelMeta] | type[ModelT]:
     """Creates a new SQLModel for the given schema for redis
 
     A new model can be defined by::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nqlstore"
 authors = [
     {name = "Martin Ahindura", email = "sales@sopherapps.com"},
 ]
-version = "0.1.0"
+version = "0.1.1"
 description = "NQLStore, a simple CRUD store python library for `any query launguage` (or in short `nql`)."
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
### Why

Type checkers were not able to identify the given models as having both properties of the schema and properties of 
the database-specific base models.

### What was Done

- Changed return types of Model functions to be Unions of Types
  By making functions like SQLModel, HashModel, MongoModel etc return Union of types, type checkers are able to view the returned Models as consisting properties and methods of both the Schema and the database specific base model (e.g. SQLModel, Document, HashModel etc.)