### PR TITLE
Release/v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.1.2] - 2025-02-15
+
+### Added
+
+- Added an `id` field to the Redis models to shadow the `pk` field
+
+### Changed
+
+- Changed the module name of the Model classes created to equal the module they are called from
+
+### Fixed
+
+- Fixed types for the `embedded_models` parameter of the `MongoModel()` and `EmbeddedModel()` functions
+
 ## [0.1.1] - 2025-02-14
 
 ### Changed

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -1,6 +1,7 @@
 """MongoDB implementation"""
 
 import re
+import sys
 from typing import Any, Iterable, Mapping, TypeVar
 
 from pydantic import BaseModel
@@ -241,6 +242,8 @@ def MongoModel(
 
     model = create_model(
         name,
+        # module of the calling function
+        __module__=sys._getframe(1).f_globals["__name__"],
         __doc__=schema.__doc__,
         __base__=(Document,),
         **fields,
@@ -282,6 +285,8 @@ def EmbeddedMongoModel(
 
     return create_model(
         name,
+        # module of the calling function
+        __module__=sys._getframe(1).f_globals["__name__"],
         __doc__=schema.__doc__,
         __base__=(_EmbeddedMongoModel,),
         **fields,

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -214,7 +214,11 @@ def MongoModel(
     schema: type[ModelT],
     /,
     embedded_models: dict[
-        str, type[_EmbeddedMongoModel] | type[list[_EmbeddedMongoModel]]
+        str,
+        type[_EmbeddedMongoModel]
+        | type[list[_EmbeddedMongoModel]]
+        | type[ModelT]
+        | type[list[ModelT]],
     ] = None,
 ) -> type[Document] | type[ModelT]:
     """Creates a new Mongo Model for the given schema
@@ -251,7 +255,11 @@ def EmbeddedMongoModel(
     schema: type[ModelT],
     /,
     embedded_models: dict[
-        str, type[_EmbeddedMongoModel] | type[list[_EmbeddedMongoModel]]
+        str,
+        type[_EmbeddedMongoModel]
+        | type[list[_EmbeddedMongoModel]]
+        | type[ModelT]
+        | type[list[ModelT]],
     ] = None,
 ) -> type[_EmbeddedMongoModel] | type[ModelT]:
     """Creates a new embedded Mongo Model for the given schema

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -146,9 +146,10 @@ def HashModel(
     """
     fields = get_field_definitions(schema, embedded_models=None, is_for_redis=True)
 
-    # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
+        # module of the calling function
+        __module__=sys._getframe(1).f_globals["__name__"],
         __doc__=schema.__doc__,
         __base__=(_HashModelMeta,),
         id=(str | None, _RedisField(default_factory=_from_pk, index=True)),
@@ -189,9 +190,10 @@ def JsonModel(
         schema, embedded_models=embedded_models, is_for_redis=True
     )
 
-    # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
+        # module of the calling function
+        __module__=sys._getframe(1).f_globals["__name__"],
         __doc__=schema.__doc__,
         __base__=(_JsonModelMeta,),
         id=(str | None, _RedisField(default_factory=_from_pk, index=True)),
@@ -223,9 +225,10 @@ def EmbeddedJsonModel(
     """
     fields = get_field_definitions(schema, embedded_models=None, is_for_redis=True)
 
-    # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
+        # module of the calling function
+        __module__=sys._getframe(1).f_globals["__name__"],
         __doc__=schema.__doc__,
         __base__=(_EmbeddedJsonModel,),
         id=(str | None, _RedisField(default_factory=_from_pk, index=True)),

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -1,5 +1,7 @@
 """Redis implementation"""
 
+import abc
+import sys
 from typing import Any, Callable, Iterable, Type, TypeVar
 
 from pydantic.main import ModelT, create_model
@@ -13,6 +15,7 @@ from ._compat import (
     _EmbeddedJsonModel,
     _HashModel,
     _JsonModel,
+    _RedisField,
     _RedisModel,
     get_redis_connection,
     verify_pipeline_response,
@@ -119,7 +122,15 @@ class RedisStore(BaseStore):
         return matched_items
 
 
-def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel] | type[ModelT]:
+class _HashModelMeta(_HashModel, abc.ABC):
+    """Base model for all HashModels. Helpful with typing"""
+
+    id: str | None
+
+
+def HashModel(
+    name: str, schema: type[ModelT], /
+) -> type[_HashModelMeta] | type[ModelT]:
     """Creates a new HashModel for the given schema for redis
 
     A new model can be defined by::
@@ -139,9 +150,16 @@ def HashModel(name: str, schema: type[ModelT], /) -> type[_HashModel] | type[Mod
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __base__=(_HashModel,),
+        __base__=(_HashModelMeta,),
+        id=(str | None, _RedisField(default_factory=_from_pk, index=True)),
         **fields,
     )
+
+
+class _JsonModelMeta(_JsonModel, abc.ABC):
+    """Base model for all JsonModels. Helpful with typing"""
+
+    id: str | None
 
 
 def JsonModel(
@@ -149,7 +167,7 @@ def JsonModel(
     schema: type[ModelT],
     /,
     embedded_models: dict[str, Type] = None,
-) -> type[_JsonModel] | type[ModelT]:
+) -> type[_JsonModelMeta] | type[ModelT]:
     """Creates a new JsonModel for the given schema for redis
 
     Note that redis supports only single embedded objects,
@@ -175,14 +193,21 @@ def JsonModel(
     return create_model(
         name,
         __doc__=schema.__doc__,
-        __base__=(_JsonModel,),
+        __base__=(_JsonModelMeta,),
+        id=(str | None, _RedisField(default_factory=_from_pk, index=True)),
         **fields,
     )
 
 
+class _EmbeddedJsonModelMeta(_EmbeddedJsonModel, abc.ABC):
+    """Base model for all EmbeddedJsonModels. Helpful with typing"""
+
+    id: str | None
+
+
 def EmbeddedJsonModel(
     name: str, schema: type[ModelT], /
-) -> type[_EmbeddedJsonModel] | type[ModelT]:
+) -> type[_EmbeddedJsonModelMeta] | type[ModelT]:
     """Creates a new EmbeddedJsonModel for the given schema for redis
 
     A new model can be defined by::
@@ -203,5 +228,18 @@ def EmbeddedJsonModel(
         name,
         __doc__=schema.__doc__,
         __base__=(_EmbeddedJsonModel,),
+        id=(str | None, _RedisField(default_factory=_from_pk, index=True)),
         **fields,
     )
+
+
+def _from_pk(data: dict) -> str | None:
+    """Extracts the pk from the already validated data
+
+    Args:
+        data: the already validated data
+
+    Returns:
+        the pk in that data
+    """
+    return data.get("pk", None)

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -1,5 +1,6 @@
 """SQL implementation"""
 
+import sys
 from typing import Any, Iterable, TypeVar, Union
 
 from pydantic import create_model
@@ -205,6 +206,8 @@ def SQLModel(
     # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
+        # module of the calling function
+        __module__=sys._getframe(1).f_globals["__name__"],
         __doc__=schema.__doc__,
         __cls_kwargs__={"table": True},
         __base__=(_SQLModelMeta,),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "nqlstore"
 authors = [
     {name = "Martin Ahindura", email = "sales@sopherapps.com"},
 ]
-version = "0.1.1"
+version = "0.1.2"
 description = "NQLStore, a simple CRUD store python library for `any query launguage` (or in short `nql`)."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_redis.py
+++ b/tests/test_redis.py
@@ -95,7 +95,7 @@ async def test_create(redis_store):
     books = [RedisBook(**v) for v in _BOOK_DATA]
     lib_data = [{**v, "books": [*books]} for v in _LIBRARY_DATA]
     got = await redis_store.insert(RedisLibrary, lib_data)
-    got = [v.model_dump(exclude={"pk"}) for v in got]
+    got = [v.model_dump(exclude={"pk", "id"}) for v in got]
     expected = [
         {**v, "books": [bk.model_dump() for bk in books]} for v in _LIBRARY_DATA
     ]

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -126,24 +126,8 @@ def _attach_test_books(
         the attached books
     """
     return [
-        model(library_id=_get_id(libs[idx % 2]), **data)
-        for idx, data in enumerate(books)
+        model(library_id=libs[idx % 2].id, **data) for idx, data in enumerate(books)
     ]
-
-
-def _get_id(lib: _LibType) -> PydanticObjectId | int | str:
-    """Gets the id of the lib
-
-    Args:
-        lib: the library to extract the id from
-
-    Returns:
-        the id or pk
-    """
-    try:
-        return lib.id
-    except AttributeError:
-        return lib.pk
 
 
 def to_sql_text(model: type[SQLModel], queries: tuple[_SQLFilter, ...]) -> str:


### PR DESCRIPTION
### Added

- Added an `id` field to the Redis models to shadow the `pk` field

### Changed

- Changed the module name of the Model classes created to equal the module they are called from

### Fixed

- Fixed types for the `embedded_models` parameter of the `MongoModel()` and `EmbeddedModel()` functions
