### PR TITLE
Enhancement/nested-like models in sql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added ability to insert children of parent models as though they were embedded in the parent 
   in SQL the SQL implementation. (This makes it possible to simulate embeddedness)
+- Added ability to replace children of SQL parent models when updating the parent
 
 ## [0.1.2] - 2025-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Added ability to insert children of parent models as though they were embedded in the parent 
+  in SQL the SQL implementation. (This makes it possible to simulate embeddedness)
+
 ## [0.1.2] - 2025-02-15
 
 ### Added

--- a/examples/todos/.gitignore
+++ b/examples/todos/.gitignore
@@ -1,0 +1,182 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# UV
+#   Similar to Pipfile.lock, it is generally recommended to include uv.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#uv.lock
+
+# poetry
+#   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.
+#   This is especially recommended for binary packages to ensure reproducibility, and is more
+#   commonly ignored for libraries.
+#   https://python-poetry.org/docs/basic-usage/#commit-your-poetrylock-file-to-version-control
+#poetry.lock
+
+# pdm
+#   Similar to Pipfile.lock, it is generally recommended to include pdm.lock in version control.
+#pdm.lock
+#   pdm stores project-wide configurations in .pdm.toml, but it is recommended to not include it
+#   in version control.
+#   https://pdm.fming.dev/latest/usage/project/#working-with-version-control
+.pdm.toml
+.pdm-python
+.pdm-build/
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# PyCharm
+#  JetBrains specific template is maintained in a separate JetBrains.gitignore that can
+#  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
+#  and can be added to the global gitignore or merged into this file.  For a more nuclear
+#  option (not recommended) you can uncomment the following to ignore the entire idea folder.
+.idea/
+
+# Ruff stuff:
+.ruff_cache/
+
+# PyPI configuration file
+.pypirc
+
+# environments
+senv/
+renv/
+menv/
+
+# pyenv
+.python-version

--- a/examples/todos/.gitignore
+++ b/examples/todos/.gitignore
@@ -167,6 +167,9 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
 
+# vscode
+.vscode/
+
 # Ruff stuff:
 .ruff_cache/
 

--- a/examples/todos/LICENSE
+++ b/examples/todos/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Martin Ahindura
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/examples/todos/README.md
+++ b/examples/todos/README.md
@@ -1,0 +1,65 @@
+# TODOs
+
+A simple TODO app based on [NQLStore](https://github.com/sopherapps/nqlstore)
+
+## Requirements
+
+- [Python +3.10](https://python.org)
+- [NQLStore](https://github.com/sopherapps/nqlstore)
+- [Redis stack (optional)](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)
+- [MongoDB (optional)](https://www.mongodb.com/products/self-managed/community-edition)
+- [SQLite (optional)](https://www.sqlite.org/)
+
+## Getting Started
+
+- Ensure you have [Python +3.10](https://python.org) installed
+
+- Copy this repository and enter this folder
+
+```shell
+git clone https://github.com/sopherapps/nqlstore.git
+cd nqlstore/examples/todos
+```
+
+- Create a virtual env, activate it and install requirements
+
+```shell
+python -m venv env 
+source env/bin/activate
+pip install -r requirements.txt
+```
+
+- To use with [MongoDB](https://www.mongodb.com/try/download/community), install and start its server.
+- To use with redis, install [redis stack](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/) 
+  and start its server in another terminal.
+
+- Start the application, selecting which database(s) to use.  
+  Options are:
+  - `--sql` for [SQLite](https://www.sqlite.org/). This the default when no option is passed
+  - `--mongo` for [MongoDB](https://www.mongodb.com/products/self-managed/community-edition)
+  - `--redis` for [Redis](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/)  
+  
+  _It is possible to use multiple databases at the same time. Just pass multiple options_
+
+```shell
+python main.py --sql # for SQL
+# python main.py --redis # for redis
+# python main.py --mongo # for mongoDB
+# python main.py --sql --mongo # for SQL and mongoDB at the sametime
+```
+
+## License
+
+Copyright (c) 2025 [Martin Ahindura](https://github.com/Tinitto)   
+Licensed under the [MIT License](./LICENSE)
+
+## Gratitude
+
+Glory be to God for His unmatchable love.
+
+> "When He had received the drink, Jesus said 'It is finished'.
+> With that, He bowed His head and gave up His Spirit."
+>
+> -- John 19: 30
+
+<a href="https://www.buymeacoffee.com/martinahinJ" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/examples/todos/conftest.py
+++ b/examples/todos/conftest.py
@@ -1,5 +1,6 @@
 """Fixtures for tests"""
 
+import os
 from dataclasses import dataclass
 from typing import Any
 
@@ -25,7 +26,10 @@ TODO_LISTS: list[dict[str, Any]] = [
 @pytest.fixture
 def sql_store():
     """The sql store stored in memory"""
-    store = SQLStore(uri="sqlite+aiosqlite:///:memory:")
+    sql_url = "sqlite+aiosqlite:///:memory:"
+    os.environ["SQL_URL"] = sql_url
+
+    store = SQLStore(uri=sql_url)
     yield store
 
 
@@ -34,7 +38,12 @@ def mongo_store():
     """The mongodb store. Requires a running instance of mongodb"""
     import pymongo
 
-    store = MongoStore(uri="mongodb://localhost:27017", database="testing")
+    mongo_url = "mongodb://localhost:27017"
+    mongo_db = "testing"
+    os.environ["MONGO_URL"] = mongo_url
+    os.environ["MONGO_DB"] = mongo_db
+
+    store = MongoStore(uri=mongo_url, database=mongo_db)
     yield store
 
     # clean up after the test
@@ -47,7 +56,10 @@ def redis_store():
     """The redis store. Requires a running instance of redis stack"""
     import redis
 
-    store = RedisStore(uri="redis://localhost:6379/0")
+    redis_url = "redis://localhost:6379/0"
+    os.environ["REDIS_URL"] = redis_url
+
+    store = RedisStore(uri=redis_url)
     yield store
 
     # clean up after the test

--- a/examples/todos/conftest.py
+++ b/examples/todos/conftest.py
@@ -32,6 +32,9 @@ def sql_store():
     store = SQLStore(uri=sql_url)
     yield store
 
+    # cleanup
+    os.environ["SQL_URL"] = ""
+
 
 @pytest.fixture
 def mongo_store():
@@ -49,6 +52,7 @@ def mongo_store():
     # clean up after the test
     client = pymongo.MongoClient("mongodb://localhost:27017")  # type: ignore
     client.drop_database("testing")
+    os.environ["MONGO_URL"] = ""
 
 
 @pytest.fixture
@@ -65,6 +69,7 @@ def redis_store():
     # clean up after the test
     client = redis.Redis("localhost", 6379, 0)
     client.flushall()
+    os.environ["REDIS_URL"] = ""
 
 
 @pytest.fixture

--- a/examples/todos/conftest.py
+++ b/examples/todos/conftest.py
@@ -1,0 +1,103 @@
+"""Fixtures for tests"""
+
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from fastapi.testclient import TestClient
+from main import MongoTodoList, RedisTodoList, SqlTodoList
+from pytest_lazyfixture import lazy_fixture
+
+from nqlstore import MongoStore, RedisStore, SQLStore
+
+STORE_MODEL_PAIRS = [
+    (lazy_fixture("sql_store"), SqlTodoList),
+    (lazy_fixture("redis_store"), RedisTodoList),
+    (lazy_fixture("mongo_store"), MongoTodoList),
+]
+
+STORE_MODEL_TODO_LISTS_TUPLES = [
+    (lazy_fixture("sql_store"), SqlTodoList, lazy_fixture("sql_todolists")),
+    (lazy_fixture("redis_store"), RedisTodoList, lazy_fixture("redis_todolists")),
+    (lazy_fixture("mongo_store"), MongoTodoList, lazy_fixture("mongo_todolists")),
+]
+
+TODO_LISTS: list[dict[str, Any]] = [
+    {"name": "School Work"},
+    {
+        "name": "Home",
+        "todos": [
+            {"title": "Make my bed"},
+            {"title": "Cook supper"},
+        ],
+    },
+    {"name": "Boo", "todos": [{"title": "Talk endlessly till daybreak"}]},
+]
+
+
+@pytest.fixture
+def sql_store():
+    """The sql store stored in memory"""
+    store = SQLStore(uri="sqlite+aiosqlite:///:memory:")
+    yield store
+
+
+@pytest.fixture
+def mongo_store():
+    """The mongodb store. Requires a running instance of mongodb"""
+    import pymongo
+
+    store = MongoStore(uri="mongodb://localhost:27017", database="testing")
+    yield store
+
+    # clean up after the test
+    client = pymongo.MongoClient("mongodb://localhost:27017")  # type: ignore
+    client.drop_database("testing")
+
+
+@pytest.fixture
+def redis_store():
+    """The redis store. Requires a running instance of redis stack"""
+    import redis
+
+    store = RedisStore(uri="redis://localhost:6379/0")
+    yield store
+
+    # clean up after the test
+    client = redis.Redis("localhost", 6379, 0)
+    client.flushall()
+
+
+@pytest.fixture
+def client():
+    """The fastapi test client"""
+    from main import app
+
+    yield TestClient(app)
+
+
+@pytest_asyncio.fixture()
+async def sql_todolists(sql_store: SQLStore):
+    """A list of todolists in the sql store"""
+    from main import SqlTodoList
+
+    records = await sql_store.insert(SqlTodoList, TODO_LISTS)
+    yield records
+
+
+@pytest_asyncio.fixture()
+async def mongo_todolists(mongo_store: MongoStore):
+    """A list of todolists in the mongo store"""
+    from .main import MongoTodoList
+
+    records = await mongo_store.insert(MongoTodoList, TODO_LISTS)
+    yield records
+
+
+@pytest_asyncio.fixture()
+async def redis_todolists(redis_store: RedisStore):
+    """A list of todolists in the redis store"""
+    from .main import RedisTodoList
+
+    records = await redis_store.insert(RedisTodoList, TODO_LISTS)
+    yield records

--- a/examples/todos/main.py
+++ b/examples/todos/main.py
@@ -1,33 +1,115 @@
-from typing import Type, TypeVar
+import os
+from contextlib import asynccontextmanager
+from typing import Annotated
 
-from fastapi import FastAPI
-from schemas import Todo, TodoList
+from fastapi import Depends, FastAPI, Query
+from models import (
+    MongoTodo,
+    MongoTodoList,
+    RedisTodo,
+    RedisTodoList,
+    SqlTodo,
+    SqlTodoList,
+)
+from schemas import TodoList
 
 from nqlstore import (
-    EmbeddedJsonModel,
-    EmbeddedMongoModel,
-    JsonModel,
-    MongoModel,
-    SQLModel,
+    MongoStore,
+    RedisStore,
+    SQLStore,
 )
+
+_SQL_STORE: SQLStore | None = None
+_REDIS_STORE: RedisStore | None = None
+_MONGO_STORE: MongoStore | None = None
+
+# dependencies
+_SqlStoreDep = Annotated[SQLStore | None, Depends(lambda: _SQL_STORE)]
+_RedisStoreDep = Annotated[RedisStore | None, Depends(lambda: _REDIS_STORE)]
+_MongoStoreDep = Annotated[MongoStore | None, Depends(lambda: _MONGO_STORE)]
+
+
+# startup events
+@asynccontextmanager
+async def lifespan(app_: FastAPI):
+    sql_url = os.environ.get("SQL_URL", "")
+    redis_url = os.environ.get("REDIS_URL", "")
+    mongo_url = os.environ.get("MONGO_URL", "")
+    mongo_db = os.environ.get("MONGO_DB", "todos")
+
+    if sql_url:
+        global _SQL_STORE
+        _SQL_STORE = SQLStore(uri=sql_url)
+        await _SQL_STORE.register([SqlTodoList, SqlTodo])
+
+    if redis_url:
+        global _REDIS_STORE
+        _REDIS_STORE = RedisStore(uri=redis_url)
+        await _REDIS_STORE.register([RedisTodoList, RedisTodo])
+
+    if mongo_url:
+        global _MONGO_STORE
+        _MONGO_STORE = MongoStore(uri=mongo_url, database=mongo_db)
+        await _MONGO_STORE.register([MongoTodoList, MongoTodo])
+
+    yield
+
 
 app = FastAPI()
 
 
-# mongo models
-MongoTodo = EmbeddedMongoModel("MongoTodo", Todo)
-MongoTodoList = MongoModel(
-    "MongoTodoList", TodoList, embedded_models={"todos": list[MongoTodo]}
-)
+@app.get("/todos/")
+async def search(
+    sql: _SqlStoreDep,
+    redis: _RedisStoreDep,
+    mongo: _MongoStoreDep,
+    q: str = Query(...),
+):
+    """Searches for todos by name"""
+    pass
 
-# redis models
-RedisTodo = EmbeddedJsonModel("RedisTodo", Todo)
-RedisTodoList = JsonModel(
-    "RedisTodoList", TodoList, embedded_models={"todos": list[RedisTodo]}
-)
 
-# sqlite models
-SqlTodoList = SQLModel(
-    "SqlTodoList", TodoList, relationships={"todos": list["SqlTodo"]}
-)
-SqlTodo = SQLModel("SqlTodo", Todo, relationships={"parent": SqlTodoList | None})
+@app.get("/todos/{id}")
+async def get_one(
+    sql: _SqlStoreDep,
+    redis: _RedisStoreDep,
+    mongo: _MongoStoreDep,
+    id: int | str,
+):
+    """Get todolist by id"""
+    pass
+
+
+@app.post("/todos/")
+async def create_one(
+    sql: _SqlStoreDep,
+    redis: _RedisStoreDep,
+    mongo: _MongoStoreDep,
+    payload: TodoList,
+):
+    """Create a todolist"""
+    pass
+
+
+@app.put("/todos/{id}")
+async def update_one(
+    sql: _SqlStoreDep,
+    redis: _RedisStoreDep,
+    mongo: _MongoStoreDep,
+    id: int | str,
+    payload: TodoList,
+):
+    """Update a todolist"""
+    pass
+
+
+@app.delete("/todos/{id}")
+async def delete_one(
+    sql: _SqlStoreDep,
+    redis: _RedisStoreDep,
+    mongo: _MongoStoreDep,
+    id: int | str,
+    payload: TodoList,
+):
+    """Delete a todolist"""
+    pass

--- a/examples/todos/main.py
+++ b/examples/todos/main.py
@@ -1,0 +1,33 @@
+from typing import Type, TypeVar
+
+from fastapi import FastAPI
+from schemas import Todo, TodoList
+
+from nqlstore import (
+    EmbeddedJsonModel,
+    EmbeddedMongoModel,
+    JsonModel,
+    MongoModel,
+    SQLModel,
+)
+
+app = FastAPI()
+
+
+# mongo models
+MongoTodo = EmbeddedMongoModel("MongoTodo", Todo)
+MongoTodoList = MongoModel(
+    "MongoTodoList", TodoList, embedded_models={"todos": list[MongoTodo]}
+)
+
+# redis models
+RedisTodo = EmbeddedJsonModel("RedisTodo", Todo)
+RedisTodoList = JsonModel(
+    "RedisTodoList", TodoList, embedded_models={"todos": list[RedisTodo]}
+)
+
+# sqlite models
+SqlTodoList = SQLModel(
+    "SqlTodoList", TodoList, relationships={"todos": list["SqlTodo"]}
+)
+SqlTodo = SQLModel("SqlTodo", Todo, relationships={"parent": SqlTodoList | None})

--- a/examples/todos/models.py
+++ b/examples/todos/models.py
@@ -1,0 +1,29 @@
+"""Models that are saved in storage"""
+
+from schemas import Todo, TodoList
+
+from nqlstore import (
+    EmbeddedJsonModel,
+    EmbeddedMongoModel,
+    JsonModel,
+    MongoModel,
+    SQLModel,
+)
+
+# mongo models
+MongoTodo = EmbeddedMongoModel("MongoTodo", Todo)
+MongoTodoList = MongoModel(
+    "MongoTodoList", TodoList, embedded_models={"todos": list[MongoTodo]}
+)
+
+# redis models
+RedisTodo = EmbeddedJsonModel("RedisTodo", Todo)
+RedisTodoList = JsonModel(
+    "RedisTodoList", TodoList, embedded_models={"todos": list[RedisTodo]}
+)
+
+# sqlite models
+SqlTodoList = SQLModel(
+    "SqlTodoList", TodoList, relationships={"todos": list["SqlTodo"]}
+)
+SqlTodo = SQLModel("SqlTodo", Todo, relationships={"parent": SqlTodoList | None})

--- a/examples/todos/requirements.txt
+++ b/examples/todos/requirements.txt
@@ -1,0 +1,7 @@
+fastapi[statndard]~=0.115.8
+nqlstore[all]
+black~=25.1.0
+isort~=6.0.0
+pytest-lazy-fixture~=0.6.3
+pytest~=8.3.4
+pytest-asyncio~=0.25.3

--- a/examples/todos/requirements.txt
+++ b/examples/todos/requirements.txt
@@ -2,6 +2,5 @@ fastapi[statndard]~=0.115.8
 nqlstore[all]
 black~=25.1.0
 isort~=6.0.0
-pytest-lazy-fixture~=0.6.3
 pytest~=8.3.4
 pytest-asyncio~=0.25.3

--- a/examples/todos/schemas.py
+++ b/examples/todos/schemas.py
@@ -1,0 +1,30 @@
+"""Schemas for the application"""
+
+from pydantic import BaseModel
+
+from nqlstore import Field, Relationship
+
+
+class TodoList(BaseModel):
+    """A list of Todos"""
+
+    name: str = Field(index=True, full_text_search=True)
+    todos: list["Todo"] = Relationship(back_populates="parent", default=[])
+
+
+class Todo(BaseModel):
+    """A single todo Item"""
+
+    title: str = Field(index=True)
+    is_complete: str = Field(default="0")
+    parent_id: int | None = Field(
+        default=None,
+        foreign_key="sqltodolist.id",
+        disable_on_mongo=True,
+        disable_on_redis=True,
+    )
+    parent: TodoList | None = Relationship(
+        back_populates="todos",
+        disable_on_mongo=True,
+        disable_on_redis=True,
+    )

--- a/examples/todos/test_main.py
+++ b/examples/todos/test_main.py
@@ -1,0 +1,187 @@
+from typing import Any
+
+import pytest
+from conftest import STORE_MODEL_PAIRS, STORE_MODEL_TODO_LISTS_TUPLES, TODO_LISTS
+from fastapi.testclient import TestClient
+
+from nqlstore._base import BaseModel, BaseStore
+
+_POST_PARAMS = [
+    (store, model, todolist)
+    for store, model in STORE_MODEL_PAIRS
+    for todolist in TODO_LISTS
+]
+_PUT_DEL_GET_PARAMS = [
+    (store, model, todolists, index)
+    for store, model, todolists in STORE_MODEL_TODO_LISTS_TUPLES
+    for index in range(len(TODO_LISTS))
+]
+_SEARCH_PARAMS = [
+    (store, model, todolist, q)
+    for store, model in STORE_MODEL_PAIRS
+    for todolist in TODO_LISTS
+    for q in ["ho", "oo", "work"]
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store, model, todolist", _POST_PARAMS)
+async def test_create_sql_todolist(
+    client: TestClient,
+    store: BaseStore,
+    model: type[BaseModel],
+    todolist: dict,
+):
+    """POST to /todos creates an empty todolist and returns it"""
+    # using context manager to ensure on_startup runs
+    with client as client:
+        response = client.post("/todos", json=todolist)
+
+        got = response.json()
+        expected = {
+            "id": got["id"],
+            "name": todolist["name"],
+            "todos": [
+                {**original, **_subdict(final, ["id"])}
+                for original, final in zip(
+                    todolist.get("todos", []), got.get("todos", [])
+                )
+            ],
+        }
+        db_record = await store.find(model, query={"id": got["id"]}, limit=1)[
+            0
+        ].model_dump()
+
+        assert got == expected
+        assert db_record == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store, model, todolists, index", _PUT_DEL_GET_PARAMS)
+async def test_update_todolist(
+    client: TestClient,
+    index: int,
+    store: BaseStore,
+    model: type[BaseModel],
+    todolists: list[BaseModel],
+):
+    """PUT to /todos/{id} updates the todolist of given id and returns updated version"""
+    todolist = todolists[index]
+    id_ = todolist.id
+    todos = [{**v.model_dump(), "is_complete": "1"} for v in todolist.todos]
+    update = {
+        "name": "some other name",
+        "todos": [*todos, {"title": "another one"}, {"title": "another one again"}],
+    }
+
+    # using context manager to ensure on_startup runs
+    with client as client:
+        response = client.put(f"/todos/{id_}", json=update)
+
+        got = response.json()
+        expected = todolist.model_copy(update=update).model_dump()
+        record_in_db = await store.find(model, query={"id": id_}, limit=1)[
+            0
+        ].model_dump()
+
+        assert got == expected
+        assert record_in_db == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store, model, todolists, index", _PUT_DEL_GET_PARAMS)
+async def test_delete_todolist(
+    client: TestClient,
+    index: int,
+    store: BaseStore,
+    model: type[BaseModel],
+    todolists: list[BaseModel],
+):
+    """DELETE /todos/{id} deletes the todolist of given id and returns deleted version"""
+    todolist = todolists[index]
+    id_ = todolist.id
+
+    # using context manager to ensure on_startup runs
+    with client as client:
+        response = client.delete(f"/todos/{id_}")
+
+        got = response.json()
+        expected = todolist.model_dump()
+        record_in_db = await store.find(model, query={"id": id_}, limit=1)
+
+        assert got == expected
+        assert record_in_db == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store, model, todolists, index", _PUT_DEL_GET_PARAMS)
+async def test_read_one_todolist(
+    client: TestClient,
+    index: int,
+    store: BaseStore,
+    model: type[BaseModel],
+    todolists: list[BaseModel],
+):
+    """GET /todos/{id} gets the todolist of given id"""
+    todolist = todolists[index]
+    id_ = todolist.id
+
+    # using context manager to ensure on_startup runs
+    with client as client:
+        response = client.get(f"/todos/{id_}")
+
+        got = response.json()
+        expected = todolist.model_dump()
+        record_in_db = await store.find(model, query={"id": id_}, limit=1)[
+            0
+        ].model_dump()
+
+        assert got == expected
+        assert record_in_db == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("store, model, todolists, q", _SEARCH_PARAMS)
+async def test_search_by_name(
+    client: TestClient,
+    store: BaseStore,
+    model: type[BaseModel],
+    todolists: list[BaseModel],
+    q: str,
+):
+    """GET /todos/?q={} gets all todos with name containing search item"""
+    # using context manager to ensure on_startup runs
+    with client as client:
+        response = client.get(f"/todos/?q={q}")
+
+        got = response.json()
+        expected = [v.model_dump() for v in todolists if q in v.name.lower()]
+
+        assert got == expected
+
+
+def _subdict(data: dict, include: list[str]) -> dict:
+    """Copies a subset of the dict with only the given keys if they exist
+
+    Args:
+        include: the keys to include
+
+    Returns:
+        dictionary with only the given keys if they exist
+    """
+    return {k: v for k, v in data.items if k in include}
+
+
+def _get_id(item: Any) -> Any:
+    """Gets the id of the given record
+
+    Args:
+        item: the reocrd whose id is to be obtained
+
+    Returns:
+        the id of the record
+    """
+    try:
+        return item.id
+    except AttributeError:
+        return item.pk

--- a/nqlstore/_mongo.py
+++ b/nqlstore/_mongo.py
@@ -81,7 +81,9 @@ class MongoStore(BaseStore):
         link_rule: WriteRules = WriteRules.DO_NOTHING,
         **pymongo_kwargs: Any,
     ) -> list[_T]:
-        parsed_items = [v if isinstance(v, model) else model(**v) for v in items]
+        parsed_items = [
+            v if isinstance(v, model) else model.model_validate(v) for v in items
+        ]
         results = await model.insert_many(
             parsed_items, session=session, link_rule=link_rule, **pymongo_kwargs
         )

--- a/nqlstore/_redis.py
+++ b/nqlstore/_redis.py
@@ -48,7 +48,9 @@ class RedisStore(BaseStore):
         pipeline_verifier: Callable[..., Any] = verify_pipeline_response,
         **kwargs,
     ) -> list[_T]:
-        parsed_items = [v if isinstance(v, model) else model(**v) for v in items]
+        parsed_items = [
+            v if isinstance(v, model) else model.model_validate(v) for v in items
+        ]
         results = await model.add(
             parsed_items, pipeline=pipeline, pipeline_verifier=pipeline_verifier
         )

--- a/nqlstore/_sql.py
+++ b/nqlstore/_sql.py
@@ -1,6 +1,7 @@
 """SQL implementation"""
 
 import sys
+from collections.abc import Mapping, MutableMapping
 from typing import Any, Iterable, TypeVar, Union
 
 from pydantic import create_model
@@ -23,7 +24,7 @@ from ._compat import (
     subqueryload,
     update,
 )
-from ._field import Field, get_field_definitions
+from ._field import Field, FieldInfo, get_field_definitions
 from .query.parsers import QueryParser
 from .query.selectors import QuerySelector
 
@@ -48,13 +49,41 @@ class SQLStore(BaseStore):
     async def insert(
         self, model: type[_T], items: Iterable[_T | dict], **kwargs
     ) -> list[_T]:
-        parsed_items = [v if isinstance(v, model) else model(**v) for v in items]
+        parsed_items = [
+            v if isinstance(v, model) else model.model_validate(v) for v in items
+        ]
+        relations_mapper = _get_relations_mapper(model)
+
         async with AsyncSession(self._engine) as session:
             stmt = insert(model).returning(model)
             cursor = await session.stream_scalars(stmt, parsed_items)
-            await session.commit()
             results = await cursor.all()
-            return list(results)
+            result_ids = [v.id for v in results]
+
+            # insert embedded items also to permit something like
+            # store.insert(Lib, [{"books": [{"title": "yay"}, ...]}])
+            # where "books" is a one-to-many relationship
+            # i.e. the kind that might be 'embedded' in Mongo-terms
+            for k, field in relations_mapper.items():
+                embedded_values = []
+
+                for idx, record in enumerate(items):
+                    parent = results[idx]
+                    raw_value = _get_key_or_prop(record, k)
+                    embedded_value = _parse_embedded(raw_value, field, parent)
+                    if isinstance(embedded_value, Iterable):
+                        embedded_values += embedded_value
+                    elif isinstance(embedded_value, _SQLModel):
+                        embedded_values.append(embedded_value)
+
+                if len(embedded_values) > 0:
+                    field_model = field.property.mapper.class_
+                    embed_stmt = insert(field_model).returning(field_model)
+                    await session.stream_scalars(embed_stmt, embedded_values)
+
+            await session.commit()
+            refreshed_results = await self.find(model, model.id.in_(result_ids))
+            return list(refreshed_results)
 
     async def find(
         self,
@@ -203,7 +232,6 @@ def SQLModel(
     """
     fields = get_field_definitions(schema, relationships=relationships, is_for_sql=True)
 
-    # FIXME: Handle scenario where a pk is defined
     return create_model(
         name,
         # module of the calling function
@@ -229,6 +257,22 @@ def _get_relations(model: type[_SQLModel]):
         for v in model.__mapper__.all_orm_descriptors.values()
         if isinstance(v.property, RelationshipProperty)
     ]
+
+
+def _get_relations_mapper(model: type[_SQLModel]) -> dict[str, Any]:
+    """Gets all the relational fields with their names of the given model
+
+    Args:
+        model: the SQL model to inspect
+
+    Returns:
+        dict of (name, Field) that have associated relationships
+    """
+    return {
+        k: v
+        for k, v in model.__mapper__.all_orm_descriptors.items()
+        if isinstance(v.property, RelationshipProperty)
+    }
 
 
 def _get_filtered_tables(filters: Iterable[_Filter]) -> list[Table]:
@@ -326,3 +370,82 @@ def _to_subquery_based_filters(
 
     # return a filter checking model id against the returned ids
     return [model.id.in_(subquery.where(*rel_filters))]
+
+
+def _get_key_or_prop(obj: dict | Any, name: str) -> Any:
+    """Gets value of a key or property from a given object or dict
+
+    Args:
+        obj: the object from which to get the value
+        name: the name of the key or property
+
+    Returns:
+        the value corresponding to the given key or property
+    """
+    if isinstance(obj, Mapping):
+        return obj.get(name, None)
+    else:
+        return getattr(obj, name, None)
+
+
+def _with_value(obj: dict | Any, field: str, value: Any) -> Any:
+    """Sets the value of a key or property of a given object or dict
+
+    Note: this mutates the object in-place
+
+    Args:
+        obj: the object
+        field: the name of the key or property
+        value: the value to set
+
+    Returns:
+        the mutated object
+    """
+    if isinstance(obj, MutableMapping):
+        obj[field] = value
+    else:
+        setattr(obj, field, value)
+
+    return obj
+
+
+def _parse_embedded(
+    value: Iterable[dict | Any] | dict | Any, field: Any, parent: _SQLModel
+) -> Iterable[_SQLModel] | _SQLModel | None:
+    """Parses embedded items that can be a single item or many into SQLModels
+
+    Args:
+        value: the value to parse
+        field: the field on which these embedded items are
+        parent: the parent SQLModel to which this value is attached
+
+    Returns:
+        An iterable of SQLModel instances or a single SQLModel instance
+        or None if value is None
+    """
+    if value is None:
+        return None
+
+    props = field.property  # type: RelationshipProperty[Any]
+    wrapper_type = props.collection_class
+    field_model = props.mapper.class_
+    fk_field = props.primaryjoin.right.name
+    parent_id_field = props.primaryjoin.left.name
+    fk_value = getattr(parent, parent_id_field)
+
+    if issubclass(wrapper_type, (list, tuple, set)):
+        # add a foreign key values to link back to parent
+        return wrapper_type(
+            [
+                field_model.model_validate(_with_value(v, fk_field, fk_value))
+                for v in value
+            ]
+        )
+    elif wrapper_type is None:
+        # add a foreign key value to link back to parent
+        linked_value = _with_value(value, fk_field, fk_value)
+        return field_model.model_validate(linked_value)
+
+    raise NotImplementedError(
+        f"relationship of type annotation {wrapper_type} not supported yet"
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -108,12 +108,15 @@ def redis_store():
 @pytest.mark.skipif(not is_lib_installed("redis_om"), reason="Requires redis_om.")
 async def inserted_redis_libs(redis_store):
     """The libraries inserted in the redis store"""
-    inserted_libs, _ = await insert_test_data(
+    inserted_libs = await insert_test_data(
         redis_store,
         library_model=RedisLibrary,
         book_model=RedisBook,
-        is_book_embedded=True,
     )
+    # sanity check
+    all_books = [bk for lib in inserted_libs for bk in lib.books]
+    assert all_books != []
+
     yield inserted_libs
 
 
@@ -128,12 +131,13 @@ def regex_params_redis(inserted_redis_libs):
 @pytest.mark.skipif(not is_lib_installed("beanie"), reason="Requires beanie.")
 async def inserted_mongo_libs(mongo_store):
     """The libraries inserted in the mongodb store"""
-    inserted_libs, _ = await insert_test_data(
-        mongo_store,
-        library_model=MongoLibrary,
-        book_model=MongoBook,
-        is_book_embedded=True,
+    inserted_libs = await insert_test_data(
+        mongo_store, library_model=MongoLibrary, book_model=MongoBook
     )
+    # sanity check
+    all_books = [bk for lib in inserted_libs for bk in lib.books]
+    assert all_books != []
+
     yield inserted_libs
 
 
@@ -148,9 +152,13 @@ def regex_params_mongo(inserted_mongo_libs):
 @pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def inserted_sql_libs(sql_store):
     """The libraries inserted in the sql store"""
-    inserted_libs, _ = await insert_test_data(
+    inserted_libs = await insert_test_data(
         sql_store, library_model=SqlLibrary, book_model=SqlBook
     )
+    # sanity check
+    all_books = [bk for lib in inserted_libs for bk in lib.books]
+    assert all_books != []
+
     yield inserted_libs
 
 

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -98,7 +98,13 @@ async def test_create(sql_store):
 @pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_update_native(sql_store, inserted_sql_libs):
     """Update should update the items that match the native filter"""
-    updates = {"address": "some new address"}
+    updates = {
+        "address": "some new address",
+        "books": [
+            {"title": "Upon this mountain"},
+            {"title": "No longer at ease"},
+        ],
+    }
     matches_query = lambda v: v.name.startswith("Bu") and v.address == _TEST_ADDRESS
 
     # in immediate response
@@ -128,7 +134,13 @@ async def test_update_native(sql_store, inserted_sql_libs):
 @pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_update_mongo_style(sql_store, inserted_sql_libs):
     """Update should update the items that match the mongodb-like filter"""
-    updates = {"address": "some new address"}
+    updates = {
+        "address": "some new address",
+        "books": [
+            {"title": "Upon this mountain"},
+            {"title": "No longer at ease"},
+        ],
+    }
     matches_query = lambda v: v.name != "Kisaasi" and v.address == _TEST_ADDRESS
 
     # in immediate response
@@ -164,7 +176,13 @@ async def test_update_mongo_style(sql_store, inserted_sql_libs):
 @pytest.mark.skipif(not is_lib_installed("sqlmodel"), reason="Requires sqlmodel.")
 async def test_update_hybrid(sql_store, inserted_sql_libs):
     """Update should update the items that match the mongodb-like filter AND the native filter"""
-    updates = {"address": "some new address"}
+    updates = {
+        "address": "some new address",
+        "books": [
+            {"title": "Upon this mountain"},
+            {"title": "No longer at ease"},
+        ],
+    }
     matches_query = lambda v: v.name.startswith("Bu") and v.address == _TEST_ADDRESS
 
     # in immediate response
@@ -196,7 +214,13 @@ async def test_update_hybrid(sql_store, inserted_sql_libs):
 async def test_update_dot_notation(sql_store, inserted_sql_libs):
     """Update should update the items that match the filter with embedded objects"""
     wanted_titles = ["Belljar", "Benediction man"]
-    updates = {"address": "some new address"}
+    updates = {
+        "address": "some new address",
+        "books": [
+            {"title": "Upon this mountain"},
+            {"title": "No longer at ease"},
+        ],
+    }
     matches_query = lambda v: any(bk.title in wanted_titles for bk in v.books)
 
     got = await sql_store.update(


### PR DESCRIPTION
### Why

We need SQL to behave as though it supports embedded models.
Thus inserts and updates should be able to upsert any children passed as part
of the payload of the parent.

We want to enable things like:

```python
# ...
await store.insert(SqlTodoList, [{
        "name": "Home",
        "todos": [
            {"title": "Make my bed"},
            {"title": "Cook supper"},
        ],
    }])
```

where "todos" is actually a one-to-many relationship targeting the `SqlTodo` model.

### What was done

- [x] Added ability to insert children of SQL parent models as though they were embedded in the parent.
- [x] Added ability to replace children of SQL parent models when updating the parent