### PR TITLE
Auto convert 'id' references in mongo queries to '_id' ObjectId Equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Automatically convert 'id' references in mongo queries to '_id' ObjectId equivalents
+
 ## [0.1.5] - 2025-02-18
 
 ### Added

--- a/examples/todos/main.py
+++ b/examples/todos/main.py
@@ -2,7 +2,6 @@ import logging
 from contextlib import asynccontextmanager
 from typing import Annotated
 
-from beanie import PydanticObjectId
 from fastapi import Depends, FastAPI, HTTPException, Query, status
 from models import MongoTodoList, RedisTodoList, SqlTodoList
 from schemas import TodoList
@@ -73,9 +72,7 @@ async def get_one(
             results += await redis.find(RedisTodoList, query=query, limit=1)
 
         if mongo:
-            results += await mongo.find(
-                MongoTodoList, query={"_id": {"$eq": PydanticObjectId(id_)}}, limit=1
-            )
+            results += await mongo.find(MongoTodoList, query=query, limit=1)
     except Exception as exp:
         logging.error(exp)
         raise exp
@@ -135,11 +132,7 @@ async def update_one(
             results += await redis.update(RedisTodoList, query=query, updates=updates)
 
         if mongo:
-            results += await mongo.update(
-                MongoTodoList,
-                query={"_id": {"$eq": PydanticObjectId(id_)}},
-                updates=updates,
-            )
+            results += await mongo.update(MongoTodoList, query=query, updates=updates)
     except Exception as exp:
         logging.error(exp)
         raise exp
@@ -169,9 +162,7 @@ async def delete_one(
             results += await redis.delete(RedisTodoList, query=query)
 
         if mongo:
-            results += await mongo.delete(
-                MongoTodoList, query={"_id": {"$eq": PydanticObjectId(id_)}}
-            )
+            results += await mongo.delete(MongoTodoList, query=query)
     except Exception as exp:
         logging.error(exp)
         raise exp


### PR DESCRIPTION
### Why

We need to be able to query mongo db as others are queried i.e. with 'id': str values

### What was done

- Added the `to_mongo()` method on parser to sanitize any queries to native mongo queries