### PR TITLE
Fix 'AttributeError: 'FieldInfo' object has no attribute 'disabled_on_mongo'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Automatically convert 'id' references in mongo queries to '_id' ObjectId equivalents
 
+### Fixed
+
+- Fixed 'AttributeError: 'FieldInfo' object has no attribute 'disable_on_mongo' when field is declared without `Field()` function
+
 ## [0.1.5] - 2025-02-18
 
 ### Added

--- a/examples/todos/schemas.py
+++ b/examples/todos/schemas.py
@@ -9,6 +9,7 @@ class TodoList(BaseModel):
     """A list of Todos"""
 
     name: str = Field(index=True, full_text_search=True)
+    description: str | None = None
     todos: list["Todo"] = Relationship(back_populates="parent", default=[])
 
 

--- a/examples/todos/test_main.py
+++ b/examples/todos/test_main.py
@@ -29,6 +29,7 @@ async def test_create_sql_todolist(
         expected = {
             "id": todolist_id,
             "name": todolist["name"],
+            "description": None,
             "todos": [
                 {
                     **raw,
@@ -66,6 +67,7 @@ async def test_create_redis_todolist(
         expected = {
             "id": todolist_id,
             "name": todolist["name"],
+            "description": None,
             "pk": todolist_id,
             "todos": [
                 {
@@ -103,6 +105,7 @@ async def test_create_mongo_todolist(
         expected = {
             "id": todolist_id,
             "name": todolist["name"],
+            "description": None,
             "todos": [
                 {
                     **raw,

--- a/nqlstore/_field.py
+++ b/nqlstore/_field.py
@@ -420,13 +420,13 @@ def get_field_definitions(
     fields = {}
     for field_name, field in schema.model_fields.items():  # type: str, FieldInfo
         class_field_definition = _get_class_field_definition(field)
-        if is_for_redis and class_field_definition.disable_on_redis:
+        if is_for_redis and getattr(class_field_definition, "disable_on_redis", False):
             continue
 
-        if is_for_mongo and class_field_definition.disable_on_mongo:
+        if is_for_mongo and getattr(class_field_definition, "disable_on_mongo", False):
             continue
 
-        if is_for_sql and class_field_definition.disable_on_sql:
+        if is_for_sql and getattr(class_field_definition, "disable_on_sql", False):
             continue
 
         field_type = field.annotation


### PR DESCRIPTION
### Why

Whenever fields were declared without `Field()` function, they would raise the Attribute error. AN example is shown below.

```python
class School:
    name: str 
```

### What was done

- Changed accessing 'disabled_on_mongo', 'disabled_on_sql' and 'disabled_on_redis' to use `getattr()` with a default `False`.